### PR TITLE
feat(generator): emit SEM001 diagnostic for unknown dimension references

### DIFF
--- a/Semantics.SourceGenerators/Generators/QuantitiesGenerator.cs
+++ b/Semantics.SourceGenerators/Generators/QuantitiesGenerator.cs
@@ -20,6 +20,14 @@ using Semantics.SourceGenerators.Templates;
 [Generator]
 public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 {
+	private static readonly DiagnosticDescriptor UnknownDimensionReference = new(
+		id: "SEM001",
+		title: "Unknown dimension reference in physics relationship",
+		messageFormat: "Dimension '{0}' references unknown dimension '{1}' in {2}; the operator will not be generated. Check spelling and that the referenced dimension exists in dimensions.json.",
+		category: "Semantics.SourceGenerators",
+		defaultSeverity: DiagnosticSeverity.Warning,
+		isEnabledByDefault: true);
+
 	public QuantitiesGenerator() : base("dimensions.json") { }
 
 	protected override void Generate(SourceProductionContext context, DimensionsMetadata metadata, CodeBlocker codeBlocker)
@@ -32,8 +40,8 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 		// Phase A: Build maps and collect operators
 		Dictionary<string, PhysicalDimension> dimensionMap = BuildDimensionMap(metadata);
 		Dictionary<string, int> typeFormMap = BuildTypeFormMap(metadata);
-		List<OperatorInfo> allOperators = CollectAllOperators(metadata, dimensionMap);
-		List<ProductInfo> allProducts = CollectAllProducts(metadata, dimensionMap);
+		List<OperatorInfo> allOperators = CollectAllOperators(context, metadata, dimensionMap);
+		List<ProductInfo> allProducts = CollectAllProducts(context, metadata, dimensionMap);
 		Dictionary<string, List<OperatorInfo>> operatorsByOwner = GroupBy(allOperators, o => o.OwnerTypeName);
 		Dictionary<string, List<ProductInfo>> productsByOwner = GroupBy(allProducts, p => p.SelfTypeName);
 
@@ -112,7 +120,7 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 		return map;
 	}
 
-	private static List<OperatorInfo> CollectAllOperators(DimensionsMetadata metadata, Dictionary<string, PhysicalDimension> dimMap)
+	private static List<OperatorInfo> CollectAllOperators(SourceProductionContext context, DimensionsMetadata metadata, Dictionary<string, PhysicalDimension> dimMap)
 	{
 		HashSet<string> seen = [];
 		List<OperatorInfo> result = [];
@@ -124,11 +132,13 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 			{
 				if (!dimMap.TryGetValue(integral.Other, out PhysicalDimension? otherDim))
 				{
+					ReportUnknownReference(context, dim.Name, integral.Other, $"integrals[{integral.Other} -> {integral.Result}].other");
 					continue;
 				}
 
 				if (!dimMap.TryGetValue(integral.Result, out PhysicalDimension? resultDim))
 				{
+					ReportUnknownReference(context, dim.Name, integral.Result, $"integrals[{integral.Other} -> {integral.Result}].result");
 					continue;
 				}
 
@@ -168,11 +178,13 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 			{
 				if (!dimMap.TryGetValue(derivative.Other, out PhysicalDimension? otherDim))
 				{
+					ReportUnknownReference(context, dim.Name, derivative.Other, $"derivatives[{derivative.Other} -> {derivative.Result}].other");
 					continue;
 				}
 
 				if (!dimMap.TryGetValue(derivative.Result, out PhysicalDimension? resultDim))
 				{
+					ReportUnknownReference(context, dim.Name, derivative.Result, $"derivatives[{derivative.Other} -> {derivative.Result}].result");
 					continue;
 				}
 
@@ -205,7 +217,7 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 		return result;
 	}
 
-	private static List<ProductInfo> CollectAllProducts(DimensionsMetadata metadata, Dictionary<string, PhysicalDimension> dimMap)
+	private static List<ProductInfo> CollectAllProducts(SourceProductionContext context, DimensionsMetadata metadata, Dictionary<string, PhysicalDimension> dimMap)
 	{
 		HashSet<string> seen = [];
 		List<ProductInfo> result = [];
@@ -217,11 +229,13 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 			{
 				if (!dimMap.TryGetValue(dot.Other, out PhysicalDimension? otherDim))
 				{
+					ReportUnknownReference(context, dim.Name, dot.Other, $"dotProducts[{dot.Other} -> {dot.Result}].other");
 					continue;
 				}
 
 				if (!dimMap.TryGetValue(dot.Result, out PhysicalDimension? resultDim))
 				{
+					ReportUnknownReference(context, dim.Name, dot.Result, $"dotProducts[{dot.Other} -> {dot.Result}].result");
 					continue;
 				}
 
@@ -255,11 +269,13 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 			{
 				if (!dimMap.TryGetValue(cross.Other, out PhysicalDimension? otherDim))
 				{
+					ReportUnknownReference(context, dim.Name, cross.Other, $"crossProducts[{cross.Other} -> {cross.Result}].other");
 					continue;
 				}
 
 				if (!dimMap.TryGetValue(cross.Result, out PhysicalDimension? resultDim))
 				{
+					ReportUnknownReference(context, dim.Name, cross.Result, $"crossProducts[{cross.Other} -> {cross.Result}].result");
 					continue;
 				}
 
@@ -295,6 +311,16 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 		{
 			list.Add(new OperatorInfo(op, left, right, ret, owner));
 		}
+	}
+
+	private static void ReportUnknownReference(SourceProductionContext context, string owningDimension, string unknownReference, string fieldPath)
+	{
+		context.ReportDiagnostic(Diagnostic.Create(
+			UnknownDimensionReference,
+			Location.None,
+			owningDimension,
+			unknownReference,
+			fieldPath));
 	}
 
 	private static Dictionary<string, List<T>> GroupBy<T>(List<T> items, Func<T, string> keySelector)


### PR DESCRIPTION
## Summary

Closes #56.

When `dimensions.json` declares an integral / derivative / dotProduct / crossProduct that targets a dimension that doesn't exist (typo, stale name after a rename), `QuantitiesGenerator` silently dropped the operator. Typos were invisible until someone noticed the missing operator at the call site.

This PR makes those failures visible:

```
warning SEM001: Dimension 'Force' references unknown dimension 'Lengt'
in integrals[Lengt -> Energy].other; the operator will not be generated.
Check spelling and that the referenced dimension exists in
dimensions.json.
```

The diagnostic is `Warning` severity — the build doesn't fail, the operator is still skipped, so existing valid metadata keeps generating identically. The change just surfaces typos in build output where they're visible.

All eight `dimMap.TryGetValue(...)` sites in `CollectAllOperators` and `CollectAllProducts` now emit `SEM001` on miss with the owning dimension, the unresolved name, and the metadata field path (e.g. `integrals[Force -> Energy].other`).

## Test plan

- [ ] CI runs and reports no warnings against the current `dimensions.json` (it's clean).
- [ ] Optional manual test: introduce a typo in `dimensions.json` (e.g. `"other": "Lengt"` instead of `"Length"`), build, observe a SEM001 warning. Revert.

🤖 Generated by Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxA4AzzqEd3vdyDCFUDPSP)_