### PR TITLE
feat(generator): SEM002 metadata validation + refresh stale generator output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,19 +51,25 @@ These are now baked into the generator and enforced by tests. **Do not reopen wi
 1. **`V0 - V0` returns the same `V0` of `T.Abs(a - b)`.** Magnitude subtraction stays non-negative; signed subtraction must use the V1 form explicitly.
 2. **Dimensionless and angular quantities have both `Ratio` (V0) and `SignedRatio` (V1) bases.** Ratios that semantically must be non-negative (e.g. `RefractiveIndex`, `MachNumber`, `SpecificGravity`) are V0 overloads of `Ratio`.
 3. **Semantic overloads widen implicitly to their base, narrow explicitly from it.** A `Weight` is implicitly a `ForceMagnitude`; the reverse requires `Weight.From(forceMagnitude)` or an explicit cast.
-4. **Physical constraints come from per-dimension metadata.** Floors like absolute zero or non-negative frequency are declared in `dimensions.json` and the generator emits `ArgumentException`-throwing guards inside the `Create`/`From*` factories.
+4. **Physical constraints are enforced structurally via the V0 (magnitude) form.** `Vector0` factories run `Vector0Guards.EnsureNonNegative` and throw `ArgumentException` on a negative value. That covers absolute zero (Temperature is V0, so Kelvin must be ≥ 0), non-negative frequency, non-negative absolute pressure, etc. Strict-positive or upper-bound constraints are not yet declared in metadata (tracked separately).
 
 ### Physical constants
 
-`PhysicalConstants` is **generated** from `dimensions.json` (and a constants fixture). Public surface:
+`PhysicalConstants` is **generated** from `domains.json`. Public surface:
 
 ```csharp
+// Domain-grouped PreciseNumber values:
+PhysicalConstants.Fundamental.SpeedOfLight
+PhysicalConstants.Fundamental.PlanckConstant
+PhysicalConstants.AngularMechanics.DegreesPerRadian
+
+// Generic accessors that materialise into any T : INumber<T>:
 PhysicalConstants.Generic.SpeedOfLight<T>()
 PhysicalConstants.Generic.PlanckConstant<T>()
-PhysicalConstants.Conversion.FeetToMeters<T>()
+PhysicalConstants.Generic.DegreesPerRadian<T>()
 ```
 
-Use these accessors instead of hard-coded numerics. Backing values are stored as `PreciseNumber` and converted with `T.CreateChecked` per call.
+Backing values are stored as `PreciseNumber` and converted with `T.CreateChecked` per call.
 
 ### Operators and physics relationships
 
@@ -139,6 +145,9 @@ var converted = sourceString.As<SourceType, TargetType>();
 - Edit `Semantics.SourceGenerators/Metadata/dimensions.json` to add a dimension, vector form, semantic overload, or relationship.
 - Rebuild `Semantics.SourceGenerators` and the consuming `Semantics.Quantities` project; emitted files appear in `Semantics.Quantities/Generated/Semantics.SourceGenerators/<GeneratorName>/`.
 - Treat generator output as committed source. Diff it before commit so accidental regressions are visible.
+- Generator diagnostics:
+  - **SEM001** — a relationship in `dimensions.json` references a dimension that does not exist (typo or rename). The operator is silently dropped.
+  - **SEM002** — schema-level validation issue (missing `name`/`symbol`, empty `availableUnits`, duplicate type names, no vector forms declared).
 - See `docs/physics-generator.md` for the full schema and an end-to-end "add a dimension" walk-through.
 
 This file is the entry point. For deeper material:

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AbsorbedDose.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AbsorbedDose.g.cs
@@ -22,6 +22,12 @@ public record AbsorbedDose<T> : PhysicalQuantity<AbsorbedDose<T>, T>, IVector0<A
 	/// </summary>
 	/// <param name="value">The value in Gray.</param>
 	/// <returns>A new <see cref="AbsorbedDose{T}"/> instance.</returns>
-	public static AbsorbedDose<T> FromGray(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AbsorbedDose<T> FromGray(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two AbsorbedDose values, returning the absolute difference as a non-negative AbsorbedDose.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AbsorbedDose<T> operator -(AbsorbedDose<T> left, AbsorbedDose<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AccelerationMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AccelerationMagnitude.g.cs
@@ -22,11 +22,13 @@ public record AccelerationMagnitude<T> : PhysicalQuantity<AccelerationMagnitude<
 	/// </summary>
 	/// <param name="value">The value in MetersPerSecondSquared.</param>
 	/// <returns>A new <see cref="AccelerationMagnitude{T}"/> instance.</returns>
-	public static AccelerationMagnitude<T> FromMetersPerSecondSquared(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AccelerationMagnitude<T> FromMetersPerSecondSquared(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two AccelerationMagnitude values, returning a signed Acceleration1D result.
+	/// Subtracts two AccelerationMagnitude values, returning the absolute difference as a non-negative AccelerationMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Acceleration1D<T> operator -(AccelerationMagnitude<T> left, AccelerationMagnitude<T> right) => Acceleration1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AccelerationMagnitude<T> operator -(AccelerationMagnitude<T> left, AccelerationMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies AccelerationMagnitude by Mass to produce ForceMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AcousticImpedance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AcousticImpedance.g.cs
@@ -22,6 +22,12 @@ public record AcousticImpedance<T> : PhysicalQuantity<AcousticImpedance<T>, T>, 
 	/// </summary>
 	/// <param name="value">The value in PascalSecondPerMeter.</param>
 	/// <returns>A new <see cref="AcousticImpedance{T}"/> instance.</returns>
-	public static AcousticImpedance<T> FromPascalSecondPerMeter(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AcousticImpedance<T> FromPascalSecondPerMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two AcousticImpedance values, returning the absolute difference as a non-negative AcousticImpedance.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AcousticImpedance<T> operator -(AcousticImpedance<T> left, AcousticImpedance<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ActivationEnergy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ActivationEnergy.g.cs
@@ -19,12 +19,14 @@ public record ActivationEnergy<T> : PhysicalQuantity<ActivationEnergy<T>, T>, IV
 	public static ActivationEnergy<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new ActivationEnergy from a value in JoulePerMole.</summary>
-	public static ActivationEnergy<T> FromJoulePerMole(T value) => Create(value);
+	public static ActivationEnergy<T> FromJoulePerMole(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to MolarEnergy.</summary>
 	public static implicit operator MolarEnergy<T>(ActivationEnergy<T> value) => MolarEnergy<T>.Create(value.Value);
 /// <summary>Explicit conversion from MolarEnergy.</summary>
 	public static explicit operator ActivationEnergy<T>(MolarEnergy<T> value) => Create(value.Value);
 /// <summary>Creates a ActivationEnergy from a MolarEnergy value.</summary>
 	public static ActivationEnergy<T> From(MolarEnergy<T> value) => Create(value.Value);
+/// <summary>Subtracts two ActivationEnergy values, returning the absolute difference as a non-negative ActivationEnergy.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ActivationEnergy<T> operator -(ActivationEnergy<T> left, ActivationEnergy<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Admittance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Admittance.g.cs
@@ -19,12 +19,14 @@ public record Admittance<T> : PhysicalQuantity<Admittance<T>, T>, IVector0<Admit
 	public static Admittance<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Admittance from a value in Siemens.</summary>
-	public static Admittance<T> FromSiemens(T value) => Create(value);
+	public static Admittance<T> FromSiemens(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Conductance.</summary>
 	public static implicit operator Conductance<T>(Admittance<T> value) => Conductance<T>.Create(value.Value);
 /// <summary>Explicit conversion from Conductance.</summary>
 	public static explicit operator Admittance<T>(Conductance<T> value) => Create(value.Value);
 /// <summary>Creates a Admittance from a Conductance value.</summary>
 	public static Admittance<T> From(Conductance<T> value) => Create(value.Value);
+/// <summary>Subtracts two Admittance values, returning the absolute difference as a non-negative Admittance.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Admittance<T> operator -(Admittance<T> left, Admittance<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Airspeed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Airspeed.g.cs
@@ -19,14 +19,14 @@ public record Airspeed<T> : PhysicalQuantity<Airspeed<T>, T>, IVector0<Airspeed<
 	public static Airspeed<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Airspeed from a value in MetersPerSecond.</summary>
-	public static Airspeed<T> FromMetersPerSecond(T value) => Create(value);
+	public static Airspeed<T> FromMetersPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Speed.</summary>
 	public static implicit operator Speed<T>(Airspeed<T> value) => Speed<T>.Create(value.Value);
 /// <summary>Explicit conversion from Speed.</summary>
 	public static explicit operator Airspeed<T>(Speed<T> value) => Create(value.Value);
 /// <summary>Creates a Airspeed from a Speed value.</summary>
 	public static Airspeed<T> From(Speed<T> value) => Create(value.Value);
-/// <summary>Subtracts two Airspeed values, returning a signed Velocity1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Velocity1D<T> operator -(Airspeed<T> left, Airspeed<T> right) => Velocity1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Airspeed values, returning the absolute difference as a non-negative Airspeed.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Airspeed<T> operator -(Airspeed<T> left, Airspeed<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Altitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Altitude.g.cs
@@ -19,14 +19,14 @@ public record Altitude<T> : PhysicalQuantity<Altitude<T>, T>, IVector0<Altitude<
 	public static Altitude<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Altitude from a value in Meter.</summary>
-	public static Altitude<T> FromMeter(T value) => Create(value);
+	public static Altitude<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Altitude<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>
 	public static explicit operator Altitude<T>(Length<T> value) => Create(value.Value);
 /// <summary>Creates a Altitude from a Length value.</summary>
 	public static Altitude<T> From(Length<T> value) => Create(value.Value);
-/// <summary>Subtracts two Altitude values, returning a signed Displacement1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Displacement1D<T> operator -(Altitude<T> left, Altitude<T> right) => Displacement1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Altitude values, returning the absolute difference as a non-negative Altitude.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Altitude<T> operator -(Altitude<T> left, Altitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AmountOfSubstance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AmountOfSubstance.g.cs
@@ -22,7 +22,13 @@ public record AmountOfSubstance<T> : PhysicalQuantity<AmountOfSubstance<T>, T>, 
 	/// </summary>
 	/// <param name="value">The value in Mole.</param>
 	/// <returns>A new <see cref="AmountOfSubstance{T}"/> instance.</returns>
-	public static AmountOfSubstance<T> FromMole(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AmountOfSubstance<T> FromMole(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two AmountOfSubstance values, returning the absolute difference as a non-negative AmountOfSubstance.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AmountOfSubstance<T> operator -(AmountOfSubstance<T> left, AmountOfSubstance<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides AmountOfSubstance by Volume to produce Concentration.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Angle.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Angle.g.cs
@@ -22,11 +22,13 @@ public record Angle<T> : PhysicalQuantity<Angle<T>, T>, IVector0<Angle<T>, T>
 	/// </summary>
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new <see cref="Angle{T}"/> instance.</returns>
-	public static Angle<T> FromRadian(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Angle<T> FromRadian(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two Angle values, returning a signed SignedAngle result.
+	/// Subtracts two Angle values, returning the absolute difference as a non-negative Angle.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SignedAngle<T> operator -(Angle<T> left, Angle<T> right) => SignedAngle<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Angle<T> operator -(Angle<T> left, Angle<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides Angle by Duration to produce AngularSpeed.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AngularAccelerationMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AngularAccelerationMagnitude.g.cs
@@ -22,11 +22,13 @@ public record AngularAccelerationMagnitude<T> : PhysicalQuantity<AngularAccelera
 	/// </summary>
 	/// <param name="value">The value in RadiansPerSecondSquared.</param>
 	/// <returns>A new <see cref="AngularAccelerationMagnitude{T}"/> instance.</returns>
-	public static AngularAccelerationMagnitude<T> FromRadiansPerSecondSquared(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AngularAccelerationMagnitude<T> FromRadiansPerSecondSquared(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two AngularAccelerationMagnitude values, returning a signed AngularAcceleration1D result.
+	/// Subtracts two AngularAccelerationMagnitude values, returning the absolute difference as a non-negative AngularAccelerationMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AngularAcceleration1D<T> operator -(AngularAccelerationMagnitude<T> left, AngularAccelerationMagnitude<T> right) => AngularAcceleration1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AngularAccelerationMagnitude<T> operator -(AngularAccelerationMagnitude<T> left, AngularAccelerationMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies AngularAccelerationMagnitude by Duration to produce AngularSpeed.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AngularJerkMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AngularJerkMagnitude.g.cs
@@ -22,11 +22,13 @@ public record AngularJerkMagnitude<T> : PhysicalQuantity<AngularJerkMagnitude<T>
 	/// </summary>
 	/// <param name="value">The value in RadiansPerSecondCubed.</param>
 	/// <returns>A new <see cref="AngularJerkMagnitude{T}"/> instance.</returns>
-	public static AngularJerkMagnitude<T> FromRadiansPerSecondCubed(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AngularJerkMagnitude<T> FromRadiansPerSecondCubed(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two AngularJerkMagnitude values, returning a signed AngularJerk1D result.
+	/// Subtracts two AngularJerkMagnitude values, returning the absolute difference as a non-negative AngularJerkMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AngularJerk1D<T> operator -(AngularJerkMagnitude<T> left, AngularJerkMagnitude<T> right) => AngularJerk1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AngularJerkMagnitude<T> operator -(AngularJerkMagnitude<T> left, AngularJerkMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies AngularJerkMagnitude by Duration to produce AngularAccelerationMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AngularMomentumMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AngularMomentumMagnitude.g.cs
@@ -22,11 +22,13 @@ public record AngularMomentumMagnitude<T> : PhysicalQuantity<AngularMomentumMagn
 	/// </summary>
 	/// <param name="value">The value in KilogramMeterSquaredPerSecond.</param>
 	/// <returns>A new <see cref="AngularMomentumMagnitude{T}"/> instance.</returns>
-	public static AngularMomentumMagnitude<T> FromKilogramMeterSquaredPerSecond(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AngularMomentumMagnitude<T> FromKilogramMeterSquaredPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two AngularMomentumMagnitude values, returning a signed AngularMomentum1D result.
+	/// Subtracts two AngularMomentumMagnitude values, returning the absolute difference as a non-negative AngularMomentumMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AngularMomentum1D<T> operator -(AngularMomentumMagnitude<T> left, AngularMomentumMagnitude<T> right) => AngularMomentum1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AngularMomentumMagnitude<T> operator -(AngularMomentumMagnitude<T> left, AngularMomentumMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides AngularMomentumMagnitude by Duration to produce TorqueMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AngularSpeed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AngularSpeed.g.cs
@@ -22,11 +22,13 @@ public record AngularSpeed<T> : PhysicalQuantity<AngularSpeed<T>, T>, IVector0<A
 	/// </summary>
 	/// <param name="value">The value in RadiansPerSecond.</param>
 	/// <returns>A new <see cref="AngularSpeed{T}"/> instance.</returns>
-	public static AngularSpeed<T> FromRadiansPerSecond(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AngularSpeed<T> FromRadiansPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two AngularSpeed values, returning a signed AngularVelocity1D result.
+	/// Subtracts two AngularSpeed values, returning the absolute difference as a non-negative AngularSpeed.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AngularVelocity1D<T> operator -(AngularSpeed<T> left, AngularSpeed<T> right) => AngularVelocity1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AngularSpeed<T> operator -(AngularSpeed<T> left, AngularSpeed<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies AngularSpeed by Duration to produce Angle.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ApertureAngle.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ApertureAngle.g.cs
@@ -19,14 +19,14 @@ public record ApertureAngle<T> : PhysicalQuantity<ApertureAngle<T>, T>, IVector0
 	public static ApertureAngle<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new ApertureAngle from a value in Radian.</summary>
-	public static ApertureAngle<T> FromRadian(T value) => Create(value);
+	public static ApertureAngle<T> FromRadian(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Angle.</summary>
 	public static implicit operator Angle<T>(ApertureAngle<T> value) => Angle<T>.Create(value.Value);
 /// <summary>Explicit conversion from Angle.</summary>
 	public static explicit operator ApertureAngle<T>(Angle<T> value) => Create(value.Value);
 /// <summary>Creates a ApertureAngle from a Angle value.</summary>
 	public static ApertureAngle<T> From(Angle<T> value) => Create(value.Value);
-/// <summary>Subtracts two ApertureAngle values, returning a signed SignedAngle result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SignedAngle<T> operator -(ApertureAngle<T> left, ApertureAngle<T> right) => SignedAngle<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two ApertureAngle values, returning the absolute difference as a non-negative ApertureAngle.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ApertureAngle<T> operator -(ApertureAngle<T> left, ApertureAngle<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Area.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Area.g.cs
@@ -22,7 +22,13 @@ public record Area<T> : PhysicalQuantity<Area<T>, T>, IVector0<Area<T>, T>
 	/// </summary>
 	/// <param name="value">The value in SquareMeter.</param>
 	/// <returns>A new <see cref="Area{T}"/> instance.</returns>
-	public static Area<T> FromSquareMeter(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Area<T> FromSquareMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Area values, returning the absolute difference as a non-negative Area.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Area<T> operator -(Area<T> left, Area<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides Area by Length to produce Length.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AtmosphericPressure.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AtmosphericPressure.g.cs
@@ -19,12 +19,14 @@ public record AtmosphericPressure<T> : PhysicalQuantity<AtmosphericPressure<T>, 
 	public static AtmosphericPressure<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new AtmosphericPressure from a value in Pascal.</summary>
-	public static AtmosphericPressure<T> FromPascal(T value) => Create(value);
+	public static AtmosphericPressure<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Pressure.</summary>
 	public static implicit operator Pressure<T>(AtmosphericPressure<T> value) => Pressure<T>.Create(value.Value);
 /// <summary>Explicit conversion from Pressure.</summary>
 	public static explicit operator AtmosphericPressure<T>(Pressure<T> value) => Create(value.Value);
 /// <summary>Creates a AtmosphericPressure from a Pressure value.</summary>
 	public static AtmosphericPressure<T> From(Pressure<T> value) => Create(value.Value);
+/// <summary>Subtracts two AtmosphericPressure values, returning the absolute difference as a non-negative AtmosphericPressure.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AtmosphericPressure<T> operator -(AtmosphericPressure<T> left, AtmosphericPressure<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AtomicMass.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AtomicMass.g.cs
@@ -19,12 +19,14 @@ public record AtomicMass<T> : PhysicalQuantity<AtomicMass<T>, T>, IVector0<Atomi
 	public static AtomicMass<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new AtomicMass from a value in Kilogram.</summary>
-	public static AtomicMass<T> FromKilogram(T value) => Create(value);
+	public static AtomicMass<T> FromKilogram(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Mass.</summary>
 	public static implicit operator Mass<T>(AtomicMass<T> value) => Mass<T>.Create(value.Value);
 /// <summary>Explicit conversion from Mass.</summary>
 	public static explicit operator AtomicMass<T>(Mass<T> value) => Create(value.Value);
 /// <summary>Creates a AtomicMass from a Mass value.</summary>
 	public static AtomicMass<T> From(Mass<T> value) => Create(value.Value);
+/// <summary>Subtracts two AtomicMass values, returning the absolute difference as a non-negative AtomicMass.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static AtomicMass<T> operator -(AtomicMass<T> left, AtomicMass<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Bandwidth.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Bandwidth.g.cs
@@ -19,12 +19,14 @@ public record Bandwidth<T> : PhysicalQuantity<Bandwidth<T>, T>, IVector0<Bandwid
 	public static Bandwidth<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Bandwidth from a value in Hertz.</summary>
-	public static Bandwidth<T> FromHertz(T value) => Create(value);
+	public static Bandwidth<T> FromHertz(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Frequency.</summary>
 	public static implicit operator Frequency<T>(Bandwidth<T> value) => Frequency<T>.Create(value.Value);
 /// <summary>Explicit conversion from Frequency.</summary>
 	public static explicit operator Bandwidth<T>(Frequency<T> value) => Create(value.Value);
 /// <summary>Creates a Bandwidth from a Frequency value.</summary>
 	public static Bandwidth<T> From(Frequency<T> value) => Create(value.Value);
+/// <summary>Subtracts two Bandwidth values, returning the absolute difference as a non-negative Bandwidth.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Bandwidth<T> operator -(Bandwidth<T> left, Bandwidth<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/BulkModulus.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/BulkModulus.g.cs
@@ -19,12 +19,14 @@ public record BulkModulus<T> : PhysicalQuantity<BulkModulus<T>, T>, IVector0<Bul
 	public static BulkModulus<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new BulkModulus from a value in Pascal.</summary>
-	public static BulkModulus<T> FromPascal(T value) => Create(value);
+	public static BulkModulus<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Pressure.</summary>
 	public static implicit operator Pressure<T>(BulkModulus<T> value) => Pressure<T>.Create(value.Value);
 /// <summary>Explicit conversion from Pressure.</summary>
 	public static explicit operator BulkModulus<T>(Pressure<T> value) => Create(value.Value);
 /// <summary>Creates a BulkModulus from a Pressure value.</summary>
 	public static BulkModulus<T> From(Pressure<T> value) => Create(value.Value);
+/// <summary>Subtracts two BulkModulus values, returning the absolute difference as a non-negative BulkModulus.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static BulkModulus<T> operator -(BulkModulus<T> left, BulkModulus<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Capacitance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Capacitance.g.cs
@@ -22,7 +22,13 @@ public record Capacitance<T> : PhysicalQuantity<Capacitance<T>, T>, IVector0<Cap
 	/// </summary>
 	/// <param name="value">The value in Farad.</param>
 	/// <returns>A new <see cref="Capacitance{T}"/> instance.</returns>
-	public static Capacitance<T> FromFarad(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Capacitance<T> FromFarad(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Capacitance values, returning the absolute difference as a non-negative Capacitance.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Capacitance<T> operator -(Capacitance<T> left, Capacitance<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Capacitance by VoltageMagnitude to produce ChargeMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Capacity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Capacity.g.cs
@@ -19,12 +19,14 @@ public record Capacity<T> : PhysicalQuantity<Capacity<T>, T>, IVector0<Capacity<
 	public static Capacity<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Capacity from a value in CubicMeter.</summary>
-	public static Capacity<T> FromCubicMeter(T value) => Create(value);
+	public static Capacity<T> FromCubicMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Volume.</summary>
 	public static implicit operator Volume<T>(Capacity<T> value) => Volume<T>.Create(value.Value);
 /// <summary>Explicit conversion from Volume.</summary>
 	public static explicit operator Capacity<T>(Volume<T> value) => Create(value.Value);
 /// <summary>Creates a Capacity from a Volume value.</summary>
 	public static Capacity<T> From(Volume<T> value) => Create(value.Value);
+/// <summary>Subtracts two Capacity values, returning the absolute difference as a non-negative Capacity.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Capacity<T> operator -(Capacity<T> left, Capacity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CatalyticActivity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CatalyticActivity.g.cs
@@ -22,7 +22,13 @@ public record CatalyticActivity<T> : PhysicalQuantity<CatalyticActivity<T>, T>, 
 	/// </summary>
 	/// <param name="value">The value in Katal.</param>
 	/// <returns>A new <see cref="CatalyticActivity{T}"/> instance.</returns>
-	public static CatalyticActivity<T> FromKatal(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static CatalyticActivity<T> FromKatal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two CatalyticActivity values, returning the absolute difference as a non-negative CatalyticActivity.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static CatalyticActivity<T> operator -(CatalyticActivity<T> left, CatalyticActivity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies CatalyticActivity by Duration to produce AmountOfSubstance.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ChargeMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ChargeMagnitude.g.cs
@@ -22,11 +22,13 @@ public record ChargeMagnitude<T> : PhysicalQuantity<ChargeMagnitude<T>, T>, IVec
 	/// </summary>
 	/// <param name="value">The value in Coulomb.</param>
 	/// <returns>A new <see cref="ChargeMagnitude{T}"/> instance.</returns>
-	public static ChargeMagnitude<T> FromCoulomb(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ChargeMagnitude<T> FromCoulomb(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two ChargeMagnitude values, returning a signed Charge result.
+	/// Subtracts two ChargeMagnitude values, returning the absolute difference as a non-negative ChargeMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Charge<T> operator -(ChargeMagnitude<T> left, ChargeMagnitude<T> right) => Charge<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ChargeMagnitude<T> operator -(ChargeMagnitude<T> left, ChargeMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides ChargeMagnitude by Duration to produce CurrentMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ClockSpeed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ClockSpeed.g.cs
@@ -19,12 +19,14 @@ public record ClockSpeed<T> : PhysicalQuantity<ClockSpeed<T>, T>, IVector0<Clock
 	public static ClockSpeed<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new ClockSpeed from a value in Hertz.</summary>
-	public static ClockSpeed<T> FromHertz(T value) => Create(value);
+	public static ClockSpeed<T> FromHertz(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Frequency.</summary>
 	public static implicit operator Frequency<T>(ClockSpeed<T> value) => Frequency<T>.Create(value.Value);
 /// <summary>Explicit conversion from Frequency.</summary>
 	public static explicit operator ClockSpeed<T>(Frequency<T> value) => Create(value.Value);
 /// <summary>Creates a ClockSpeed from a Frequency value.</summary>
 	public static ClockSpeed<T> From(Frequency<T> value) => Create(value.Value);
+/// <summary>Subtracts two ClockSpeed values, returning the absolute difference as a non-negative ClockSpeed.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ClockSpeed<T> operator -(ClockSpeed<T> left, ClockSpeed<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Concentration.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Concentration.g.cs
@@ -22,7 +22,13 @@ public record Concentration<T> : PhysicalQuantity<Concentration<T>, T>, IVector0
 	/// </summary>
 	/// <param name="value">The value in Molar.</param>
 	/// <returns>A new <see cref="Concentration{T}"/> instance.</returns>
-	public static Concentration<T> FromMolar(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Concentration<T> FromMolar(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Concentration values, returning the absolute difference as a non-negative Concentration.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Concentration<T> operator -(Concentration<T> left, Concentration<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Concentration by Volume to produce AmountOfSubstance.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Conductance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Conductance.g.cs
@@ -22,7 +22,13 @@ public record Conductance<T> : PhysicalQuantity<Conductance<T>, T>, IVector0<Con
 	/// </summary>
 	/// <param name="value">The value in Siemens.</param>
 	/// <returns>A new <see cref="Conductance{T}"/> instance.</returns>
-	public static Conductance<T> FromSiemens(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Conductance<T> FromSiemens(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Conductance values, returning the absolute difference as a non-negative Conductance.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Conductance<T> operator -(Conductance<T> left, Conductance<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Conductance by VoltageMagnitude to produce CurrentMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CrossSectionalArea.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CrossSectionalArea.g.cs
@@ -19,12 +19,14 @@ public record CrossSectionalArea<T> : PhysicalQuantity<CrossSectionalArea<T>, T>
 	public static CrossSectionalArea<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new CrossSectionalArea from a value in SquareMeter.</summary>
-	public static CrossSectionalArea<T> FromSquareMeter(T value) => Create(value);
+	public static CrossSectionalArea<T> FromSquareMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Area.</summary>
 	public static implicit operator Area<T>(CrossSectionalArea<T> value) => Area<T>.Create(value.Value);
 /// <summary>Explicit conversion from Area.</summary>
 	public static explicit operator CrossSectionalArea<T>(Area<T> value) => Create(value.Value);
 /// <summary>Creates a CrossSectionalArea from a Area value.</summary>
 	public static CrossSectionalArea<T> From(Area<T> value) => Create(value.Value);
+/// <summary>Subtracts two CrossSectionalArea values, returning the absolute difference as a non-negative CrossSectionalArea.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static CrossSectionalArea<T> operator -(CrossSectionalArea<T> left, CrossSectionalArea<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CurrentMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CurrentMagnitude.g.cs
@@ -22,11 +22,13 @@ public record CurrentMagnitude<T> : PhysicalQuantity<CurrentMagnitude<T>, T>, IV
 	/// </summary>
 	/// <param name="value">The value in Ampere.</param>
 	/// <returns>A new <see cref="CurrentMagnitude{T}"/> instance.</returns>
-	public static CurrentMagnitude<T> FromAmpere(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static CurrentMagnitude<T> FromAmpere(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two CurrentMagnitude values, returning a signed Current1D result.
+	/// Subtracts two CurrentMagnitude values, returning the absolute difference as a non-negative CurrentMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Current1D<T> operator -(CurrentMagnitude<T> left, CurrentMagnitude<T> right) => Current1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static CurrentMagnitude<T> operator -(CurrentMagnitude<T> left, CurrentMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies CurrentMagnitude by Duration to produce ChargeMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/DecayTime.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/DecayTime.g.cs
@@ -19,12 +19,14 @@ public record DecayTime<T> : PhysicalQuantity<DecayTime<T>, T>, IVector0<DecayTi
 	public static DecayTime<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new DecayTime from a value in Second.</summary>
-	public static DecayTime<T> FromSecond(T value) => Create(value);
+	public static DecayTime<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Duration.</summary>
 	public static implicit operator Duration<T>(DecayTime<T> value) => Duration<T>.Create(value.Value);
 /// <summary>Explicit conversion from Duration.</summary>
 	public static explicit operator DecayTime<T>(Duration<T> value) => Create(value.Value);
 /// <summary>Creates a DecayTime from a Duration value.</summary>
 	public static DecayTime<T> From(Duration<T> value) => Create(value.Value);
+/// <summary>Subtracts two DecayTime values, returning the absolute difference as a non-negative DecayTime.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static DecayTime<T> operator -(DecayTime<T> left, DecayTime<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Density.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Density.g.cs
@@ -22,7 +22,13 @@ public record Density<T> : PhysicalQuantity<Density<T>, T>, IVector0<Density<T>,
 	/// </summary>
 	/// <param name="value">The value in KilogramPerCubicMeter.</param>
 	/// <returns>A new <see cref="Density{T}"/> instance.</returns>
-	public static Density<T> FromKilogramPerCubicMeter(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Density<T> FromKilogramPerCubicMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Density values, returning the absolute difference as a non-negative Density.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Density<T> operator -(Density<T> left, Density<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Density by Volume to produce Mass.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Depth.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Depth.g.cs
@@ -19,14 +19,14 @@ public record Depth<T> : PhysicalQuantity<Depth<T>, T>, IVector0<Depth<T>, T>
 	public static Depth<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Depth from a value in Meter.</summary>
-	public static Depth<T> FromMeter(T value) => Create(value);
+	public static Depth<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Depth<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>
 	public static explicit operator Depth<T>(Length<T> value) => Create(value.Value);
 /// <summary>Creates a Depth from a Length value.</summary>
 	public static Depth<T> From(Length<T> value) => Create(value.Value);
-/// <summary>Subtracts two Depth values, returning a signed Displacement1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Displacement1D<T> operator -(Depth<T> left, Depth<T> right) => Displacement1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Depth values, returning the absolute difference as a non-negative Depth.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Depth<T> operator -(Depth<T> left, Depth<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Diameter.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Diameter.g.cs
@@ -19,15 +19,15 @@ public record Diameter<T> : PhysicalQuantity<Diameter<T>, T>, IVector0<Diameter<
 	public static Diameter<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Diameter from a value in Meter.</summary>
-	public static Diameter<T> FromMeter(T value) => Create(value);
+	public static Diameter<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Diameter<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>
 	public static explicit operator Diameter<T>(Length<T> value) => Create(value.Value);
 /// <summary>Creates a Diameter from a Length value.</summary>
 	public static Diameter<T> From(Length<T> value) => Create(value.Value);
-/// <summary>Subtracts two Diameter values, returning a signed Displacement1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Displacement1D<T> operator -(Diameter<T> left, Diameter<T> right) => Displacement1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Diameter values, returning the absolute difference as a non-negative Diameter.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Diameter<T> operator -(Diameter<T> left, Diameter<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>Converts this Diameter to a Radius.</summary>
 	public Radius<T> ToRadius() => Radius<T>.Create(Value / T.CreateChecked(2));
 /// <summary>Creates a Diameter from a Radius value.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Distance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Distance.g.cs
@@ -19,14 +19,14 @@ public record Distance<T> : PhysicalQuantity<Distance<T>, T>, IVector0<Distance<
 	public static Distance<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Distance from a value in Meter.</summary>
-	public static Distance<T> FromMeter(T value) => Create(value);
+	public static Distance<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Distance<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>
 	public static explicit operator Distance<T>(Length<T> value) => Create(value.Value);
 /// <summary>Creates a Distance from a Length value.</summary>
 	public static Distance<T> From(Length<T> value) => Create(value.Value);
-/// <summary>Subtracts two Distance values, returning a signed Displacement1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Displacement1D<T> operator -(Distance<T> left, Distance<T> right) => Displacement1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Distance values, returning the absolute difference as a non-negative Distance.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Distance<T> operator -(Distance<T> left, Distance<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Drag.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Drag.g.cs
@@ -19,14 +19,14 @@ public record Drag<T> : PhysicalQuantity<Drag<T>, T>, IVector0<Drag<T>, T>
 	public static Drag<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Drag from a value in Newton.</summary>
-	public static Drag<T> FromNewton(T value) => Create(value);
+	public static Drag<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(Drag<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>
 	public static explicit operator Drag<T>(ForceMagnitude<T> value) => Create(value.Value);
 /// <summary>Creates a Drag from a ForceMagnitude value.</summary>
 	public static Drag<T> From(ForceMagnitude<T> value) => Create(value.Value);
-/// <summary>Subtracts two Drag values, returning a signed Force1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Force1D<T> operator -(Drag<T> left, Drag<T> right) => Force1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Drag values, returning the absolute difference as a non-negative Drag.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Drag<T> operator -(Drag<T> left, Drag<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Duration.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Duration.g.cs
@@ -22,7 +22,13 @@ public record Duration<T> : PhysicalQuantity<Duration<T>, T>, IVector0<Duration<
 	/// </summary>
 	/// <param name="value">The value in Second.</param>
 	/// <returns>A new <see cref="Duration{T}"/> instance.</returns>
-	public static Duration<T> FromSecond(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Duration<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Duration values, returning the absolute difference as a non-negative Duration.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Duration<T> operator -(Duration<T> left, Duration<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Duration by CurrentMagnitude to produce ChargeMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/DynamicViscosity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/DynamicViscosity.g.cs
@@ -22,7 +22,13 @@ public record DynamicViscosity<T> : PhysicalQuantity<DynamicViscosity<T>, T>, IV
 	/// </summary>
 	/// <param name="value">The value in PascalSecond.</param>
 	/// <returns>A new <see cref="DynamicViscosity{T}"/> instance.</returns>
-	public static DynamicViscosity<T> FromPascalSecond(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static DynamicViscosity<T> FromPascalSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two DynamicViscosity values, returning the absolute difference as a non-negative DynamicViscosity.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static DynamicViscosity<T> operator -(DynamicViscosity<T> left, DynamicViscosity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides DynamicViscosity by Density to produce KinematicViscosity.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EMF.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EMF.g.cs
@@ -19,14 +19,14 @@ public record EMF<T> : PhysicalQuantity<EMF<T>, T>, IVector0<EMF<T>, T>
 	public static EMF<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new EMF from a value in Volt.</summary>
-	public static EMF<T> FromVolt(T value) => Create(value);
+	public static EMF<T> FromVolt(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to VoltageMagnitude.</summary>
 	public static implicit operator VoltageMagnitude<T>(EMF<T> value) => VoltageMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from VoltageMagnitude.</summary>
 	public static explicit operator EMF<T>(VoltageMagnitude<T> value) => Create(value.Value);
 /// <summary>Creates a EMF from a VoltageMagnitude value.</summary>
 	public static EMF<T> From(VoltageMagnitude<T> value) => Create(value.Value);
-/// <summary>Subtracts two EMF values, returning a signed Voltage result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Voltage<T> operator -(EMF<T> left, EMF<T> right) => Voltage<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two EMF values, returning the absolute difference as a non-negative EMF.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static EMF<T> operator -(EMF<T> left, EMF<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ElectricFieldMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ElectricFieldMagnitude.g.cs
@@ -22,11 +22,13 @@ public record ElectricFieldMagnitude<T> : PhysicalQuantity<ElectricFieldMagnitud
 	/// </summary>
 	/// <param name="value">The value in VoltPerMeter.</param>
 	/// <returns>A new <see cref="ElectricFieldMagnitude{T}"/> instance.</returns>
-	public static ElectricFieldMagnitude<T> FromVoltPerMeter(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ElectricFieldMagnitude<T> FromVoltPerMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two ElectricFieldMagnitude values, returning a signed ElectricField1D result.
+	/// Subtracts two ElectricFieldMagnitude values, returning the absolute difference as a non-negative ElectricFieldMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ElectricField1D<T> operator -(ElectricFieldMagnitude<T> left, ElectricFieldMagnitude<T> right) => ElectricField1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ElectricFieldMagnitude<T> operator -(ElectricFieldMagnitude<T> left, ElectricFieldMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies ElectricFieldMagnitude by Length to produce VoltageMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Energy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Energy.g.cs
@@ -22,7 +22,13 @@ public record Energy<T> : PhysicalQuantity<Energy<T>, T>, IVector0<Energy<T>, T>
 	/// </summary>
 	/// <param name="value">The value in Joule.</param>
 	/// <returns>A new <see cref="Energy{T}"/> instance.</returns>
-	public static Energy<T> FromJoule(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Energy<T> FromJoule(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Energy values, returning the absolute difference as a non-negative Energy.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Energy<T> operator -(Energy<T> left, Energy<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides Energy by Angle to produce TorqueMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EnergyFluxDensity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EnergyFluxDensity.g.cs
@@ -19,12 +19,14 @@ public record EnergyFluxDensity<T> : PhysicalQuantity<EnergyFluxDensity<T>, T>, 
 	public static EnergyFluxDensity<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new EnergyFluxDensity from a value in WattPerSquareMeter.</summary>
-	public static EnergyFluxDensity<T> FromWattPerSquareMeter(T value) => Create(value);
+	public static EnergyFluxDensity<T> FromWattPerSquareMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Irradiance.</summary>
 	public static implicit operator Irradiance<T>(EnergyFluxDensity<T> value) => Irradiance<T>.Create(value.Value);
 /// <summary>Explicit conversion from Irradiance.</summary>
 	public static explicit operator EnergyFluxDensity<T>(Irradiance<T> value) => Create(value.Value);
 /// <summary>Creates a EnergyFluxDensity from a Irradiance value.</summary>
 	public static EnergyFluxDensity<T> From(Irradiance<T> value) => Create(value.Value);
+/// <summary>Subtracts two EnergyFluxDensity values, returning the absolute difference as a non-negative EnergyFluxDensity.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static EnergyFluxDensity<T> operator -(EnergyFluxDensity<T> left, EnergyFluxDensity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Entropy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Entropy.g.cs
@@ -22,7 +22,13 @@ public record Entropy<T> : PhysicalQuantity<Entropy<T>, T>, IVector0<Entropy<T>,
 	/// </summary>
 	/// <param name="value">The value in JoulePerKelvin.</param>
 	/// <returns>A new <see cref="Entropy{T}"/> instance.</returns>
-	public static Entropy<T> FromJoulePerKelvin(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Entropy<T> FromJoulePerKelvin(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Entropy values, returning the absolute difference as a non-negative Entropy.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Entropy<T> operator -(Entropy<T> left, Entropy<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Entropy by Temperature to produce Energy.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EnzymeActivity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EnzymeActivity.g.cs
@@ -19,12 +19,14 @@ public record EnzymeActivity<T> : PhysicalQuantity<EnzymeActivity<T>, T>, IVecto
 	public static EnzymeActivity<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new EnzymeActivity from a value in Katal.</summary>
-	public static EnzymeActivity<T> FromKatal(T value) => Create(value);
+	public static EnzymeActivity<T> FromKatal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to CatalyticActivity.</summary>
 	public static implicit operator CatalyticActivity<T>(EnzymeActivity<T> value) => CatalyticActivity<T>.Create(value.Value);
 /// <summary>Explicit conversion from CatalyticActivity.</summary>
 	public static explicit operator EnzymeActivity<T>(CatalyticActivity<T> value) => Create(value.Value);
 /// <summary>Creates a EnzymeActivity from a CatalyticActivity value.</summary>
 	public static EnzymeActivity<T> From(CatalyticActivity<T> value) => Create(value.Value);
+/// <summary>Subtracts two EnzymeActivity values, returning the absolute difference as a non-negative EnzymeActivity.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static EnzymeActivity<T> operator -(EnzymeActivity<T> left, EnzymeActivity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EquivalentDose.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EquivalentDose.g.cs
@@ -22,6 +22,12 @@ public record EquivalentDose<T> : PhysicalQuantity<EquivalentDose<T>, T>, IVecto
 	/// </summary>
 	/// <param name="value">The value in Sievert.</param>
 	/// <returns>A new <see cref="EquivalentDose{T}"/> instance.</returns>
-	public static EquivalentDose<T> FromSievert(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static EquivalentDose<T> FromSievert(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two EquivalentDose values, returning the absolute difference as a non-negative EquivalentDose.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static EquivalentDose<T> operator -(EquivalentDose<T> left, EquivalentDose<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Exposure.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Exposure.g.cs
@@ -22,6 +22,12 @@ public record Exposure<T> : PhysicalQuantity<Exposure<T>, T>, IVector0<Exposure<
 	/// </summary>
 	/// <param name="value">The value in CoulombPerKilogram.</param>
 	/// <returns>A new <see cref="Exposure{T}"/> instance.</returns>
-	public static Exposure<T> FromCoulombPerKilogram(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Exposure<T> FromCoulombPerKilogram(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Exposure values, returning the absolute difference as a non-negative Exposure.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Exposure<T> operator -(Exposure<T> left, Exposure<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/FieldOfView.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/FieldOfView.g.cs
@@ -19,14 +19,14 @@ public record FieldOfView<T> : PhysicalQuantity<FieldOfView<T>, T>, IVector0<Fie
 	public static FieldOfView<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new FieldOfView from a value in Radian.</summary>
-	public static FieldOfView<T> FromRadian(T value) => Create(value);
+	public static FieldOfView<T> FromRadian(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Angle.</summary>
 	public static implicit operator Angle<T>(FieldOfView<T> value) => Angle<T>.Create(value.Value);
 /// <summary>Explicit conversion from Angle.</summary>
 	public static explicit operator FieldOfView<T>(Angle<T> value) => Create(value.Value);
 /// <summary>Creates a FieldOfView from a Angle value.</summary>
 	public static FieldOfView<T> From(Angle<T> value) => Create(value.Value);
-/// <summary>Subtracts two FieldOfView values, returning a signed SignedAngle result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SignedAngle<T> operator -(FieldOfView<T> left, FieldOfView<T> right) => SignedAngle<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two FieldOfView values, returning the absolute difference as a non-negative FieldOfView.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static FieldOfView<T> operator -(FieldOfView<T> left, FieldOfView<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/FlowSpeed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/FlowSpeed.g.cs
@@ -19,14 +19,14 @@ public record FlowSpeed<T> : PhysicalQuantity<FlowSpeed<T>, T>, IVector0<FlowSpe
 	public static FlowSpeed<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new FlowSpeed from a value in MetersPerSecond.</summary>
-	public static FlowSpeed<T> FromMetersPerSecond(T value) => Create(value);
+	public static FlowSpeed<T> FromMetersPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Speed.</summary>
 	public static implicit operator Speed<T>(FlowSpeed<T> value) => Speed<T>.Create(value.Value);
 /// <summary>Explicit conversion from Speed.</summary>
 	public static explicit operator FlowSpeed<T>(Speed<T> value) => Create(value.Value);
 /// <summary>Creates a FlowSpeed from a Speed value.</summary>
 	public static FlowSpeed<T> From(Speed<T> value) => Create(value.Value);
-/// <summary>Subtracts two FlowSpeed values, returning a signed Velocity1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Velocity1D<T> operator -(FlowSpeed<T> left, FlowSpeed<T> right) => Velocity1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two FlowSpeed values, returning the absolute difference as a non-negative FlowSpeed.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static FlowSpeed<T> operator -(FlowSpeed<T> left, FlowSpeed<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ForceMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ForceMagnitude.g.cs
@@ -22,11 +22,13 @@ public record ForceMagnitude<T> : PhysicalQuantity<ForceMagnitude<T>, T>, IVecto
 	/// </summary>
 	/// <param name="value">The value in Newton.</param>
 	/// <returns>A new <see cref="ForceMagnitude{T}"/> instance.</returns>
-	public static ForceMagnitude<T> FromNewton(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ForceMagnitude<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two ForceMagnitude values, returning a signed Force1D result.
+	/// Subtracts two ForceMagnitude values, returning the absolute difference as a non-negative ForceMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Force1D<T> operator -(ForceMagnitude<T> left, ForceMagnitude<T> right) => Force1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ForceMagnitude<T> operator -(ForceMagnitude<T> left, ForceMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides ForceMagnitude by AccelerationMagnitude to produce Mass.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Frequency.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Frequency.g.cs
@@ -22,7 +22,13 @@ public record Frequency<T> : PhysicalQuantity<Frequency<T>, T>, IVector0<Frequen
 	/// </summary>
 	/// <param name="value">The value in Hertz.</param>
 	/// <returns>A new <see cref="Frequency{T}"/> instance.</returns>
-	public static Frequency<T> FromHertz(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Frequency<T> FromHertz(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Frequency values, returning the absolute difference as a non-negative Frequency.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Frequency<T> operator -(Frequency<T> left, Frequency<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Frequency by Duration to produce Ratio.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Friction.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Friction.g.cs
@@ -19,14 +19,14 @@ public record Friction<T> : PhysicalQuantity<Friction<T>, T>, IVector0<Friction<
 	public static Friction<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Friction from a value in Newton.</summary>
-	public static Friction<T> FromNewton(T value) => Create(value);
+	public static Friction<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(Friction<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>
 	public static explicit operator Friction<T>(ForceMagnitude<T> value) => Create(value.Value);
 /// <summary>Creates a Friction from a ForceMagnitude value.</summary>
 	public static Friction<T> From(ForceMagnitude<T> value) => Create(value.Value);
-/// <summary>Subtracts two Friction values, returning a signed Force1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Force1D<T> operator -(Friction<T> left, Friction<T> right) => Force1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Friction values, returning the absolute difference as a non-negative Friction.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Friction<T> operator -(Friction<T> left, Friction<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GaugePressure.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GaugePressure.g.cs
@@ -19,12 +19,14 @@ public record GaugePressure<T> : PhysicalQuantity<GaugePressure<T>, T>, IVector0
 	public static GaugePressure<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new GaugePressure from a value in Pascal.</summary>
-	public static GaugePressure<T> FromPascal(T value) => Create(value);
+	public static GaugePressure<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Pressure.</summary>
 	public static implicit operator Pressure<T>(GaugePressure<T> value) => Pressure<T>.Create(value.Value);
 /// <summary>Explicit conversion from Pressure.</summary>
 	public static explicit operator GaugePressure<T>(Pressure<T> value) => Create(value.Value);
 /// <summary>Creates a GaugePressure from a Pressure value.</summary>
 	public static GaugePressure<T> From(Pressure<T> value) => Create(value.Value);
+/// <summary>Subtracts two GaugePressure values, returning the absolute difference as a non-negative GaugePressure.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static GaugePressure<T> operator -(GaugePressure<T> left, GaugePressure<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GravitationalAcceleration.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GravitationalAcceleration.g.cs
@@ -19,14 +19,14 @@ public record GravitationalAcceleration<T> : PhysicalQuantity<GravitationalAccel
 	public static GravitationalAcceleration<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new GravitationalAcceleration from a value in MetersPerSecondSquared.</summary>
-	public static GravitationalAcceleration<T> FromMetersPerSecondSquared(T value) => Create(value);
+	public static GravitationalAcceleration<T> FromMetersPerSecondSquared(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to AccelerationMagnitude.</summary>
 	public static implicit operator AccelerationMagnitude<T>(GravitationalAcceleration<T> value) => AccelerationMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from AccelerationMagnitude.</summary>
 	public static explicit operator GravitationalAcceleration<T>(AccelerationMagnitude<T> value) => Create(value.Value);
 /// <summary>Creates a GravitationalAcceleration from a AccelerationMagnitude value.</summary>
 	public static GravitationalAcceleration<T> From(AccelerationMagnitude<T> value) => Create(value.Value);
-/// <summary>Subtracts two GravitationalAcceleration values, returning a signed Acceleration1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Acceleration1D<T> operator -(GravitationalAcceleration<T> left, GravitationalAcceleration<T> right) => Acceleration1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two GravitationalAcceleration values, returning the absolute difference as a non-negative GravitationalAcceleration.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static GravitationalAcceleration<T> operator -(GravitationalAcceleration<T> left, GravitationalAcceleration<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GroundSpeed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GroundSpeed.g.cs
@@ -19,14 +19,14 @@ public record GroundSpeed<T> : PhysicalQuantity<GroundSpeed<T>, T>, IVector0<Gro
 	public static GroundSpeed<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new GroundSpeed from a value in MetersPerSecond.</summary>
-	public static GroundSpeed<T> FromMetersPerSecond(T value) => Create(value);
+	public static GroundSpeed<T> FromMetersPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Speed.</summary>
 	public static implicit operator Speed<T>(GroundSpeed<T> value) => Speed<T>.Create(value.Value);
 /// <summary>Explicit conversion from Speed.</summary>
 	public static explicit operator GroundSpeed<T>(Speed<T> value) => Create(value.Value);
 /// <summary>Creates a GroundSpeed from a Speed value.</summary>
 	public static GroundSpeed<T> From(Speed<T> value) => Create(value.Value);
-/// <summary>Subtracts two GroundSpeed values, returning a signed Velocity1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Velocity1D<T> operator -(GroundSpeed<T> left, GroundSpeed<T> right) => Velocity1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two GroundSpeed values, returning the absolute difference as a non-negative GroundSpeed.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static GroundSpeed<T> operator -(GroundSpeed<T> left, GroundSpeed<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GroupVelocity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GroupVelocity.g.cs
@@ -19,14 +19,14 @@ public record GroupVelocity<T> : PhysicalQuantity<GroupVelocity<T>, T>, IVector0
 	public static GroupVelocity<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new GroupVelocity from a value in MetersPerSecond.</summary>
-	public static GroupVelocity<T> FromMetersPerSecond(T value) => Create(value);
+	public static GroupVelocity<T> FromMetersPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Speed.</summary>
 	public static implicit operator Speed<T>(GroupVelocity<T> value) => Speed<T>.Create(value.Value);
 /// <summary>Explicit conversion from Speed.</summary>
 	public static explicit operator GroupVelocity<T>(Speed<T> value) => Create(value.Value);
 /// <summary>Creates a GroupVelocity from a Speed value.</summary>
 	public static GroupVelocity<T> From(Speed<T> value) => Create(value.Value);
-/// <summary>Subtracts two GroupVelocity values, returning a signed Velocity1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Velocity1D<T> operator -(GroupVelocity<T> left, GroupVelocity<T> right) => Velocity1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two GroupVelocity values, returning the absolute difference as a non-negative GroupVelocity.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static GroupVelocity<T> operator -(GroupVelocity<T> left, GroupVelocity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HalfLife.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HalfLife.g.cs
@@ -19,12 +19,14 @@ public record HalfLife<T> : PhysicalQuantity<HalfLife<T>, T>, IVector0<HalfLife<
 	public static HalfLife<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new HalfLife from a value in Second.</summary>
-	public static HalfLife<T> FromSecond(T value) => Create(value);
+	public static HalfLife<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Duration.</summary>
 	public static implicit operator Duration<T>(HalfLife<T> value) => Duration<T>.Create(value.Value);
 /// <summary>Explicit conversion from Duration.</summary>
 	public static explicit operator HalfLife<T>(Duration<T> value) => Create(value.Value);
 /// <summary>Creates a HalfLife from a Duration value.</summary>
 	public static HalfLife<T> From(Duration<T> value) => Create(value.Value);
+/// <summary>Subtracts two HalfLife values, returning the absolute difference as a non-negative HalfLife.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static HalfLife<T> operator -(HalfLife<T> left, HalfLife<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Heat.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Heat.g.cs
@@ -19,12 +19,14 @@ public record Heat<T> : PhysicalQuantity<Heat<T>, T>, IVector0<Heat<T>, T>
 	public static Heat<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Heat from a value in Joule.</summary>
-	public static Heat<T> FromJoule(T value) => Create(value);
+	public static Heat<T> FromJoule(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Energy.</summary>
 	public static implicit operator Energy<T>(Heat<T> value) => Energy<T>.Create(value.Value);
 /// <summary>Explicit conversion from Energy.</summary>
 	public static explicit operator Heat<T>(Energy<T> value) => Create(value.Value);
 /// <summary>Creates a Heat from a Energy value.</summary>
 	public static Heat<T> From(Energy<T> value) => Create(value.Value);
+/// <summary>Subtracts two Heat values, returning the absolute difference as a non-negative Heat.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Heat<T> operator -(Heat<T> left, Heat<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HeatCapacity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HeatCapacity.g.cs
@@ -19,12 +19,14 @@ public record HeatCapacity<T> : PhysicalQuantity<HeatCapacity<T>, T>, IVector0<H
 	public static HeatCapacity<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new HeatCapacity from a value in JoulePerKelvin.</summary>
-	public static HeatCapacity<T> FromJoulePerKelvin(T value) => Create(value);
+	public static HeatCapacity<T> FromJoulePerKelvin(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Entropy.</summary>
 	public static implicit operator Entropy<T>(HeatCapacity<T> value) => Entropy<T>.Create(value.Value);
 /// <summary>Explicit conversion from Entropy.</summary>
 	public static explicit operator HeatCapacity<T>(Entropy<T> value) => Create(value.Value);
 /// <summary>Creates a HeatCapacity from a Entropy value.</summary>
 	public static HeatCapacity<T> From(Entropy<T> value) => Create(value.Value);
+/// <summary>Subtracts two HeatCapacity values, returning the absolute difference as a non-negative HeatCapacity.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static HeatCapacity<T> operator -(HeatCapacity<T> left, HeatCapacity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HeatFlowRate.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HeatFlowRate.g.cs
@@ -19,12 +19,14 @@ public record HeatFlowRate<T> : PhysicalQuantity<HeatFlowRate<T>, T>, IVector0<H
 	public static HeatFlowRate<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new HeatFlowRate from a value in Watt.</summary>
-	public static HeatFlowRate<T> FromWatt(T value) => Create(value);
+	public static HeatFlowRate<T> FromWatt(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Power.</summary>
 	public static implicit operator Power<T>(HeatFlowRate<T> value) => Power<T>.Create(value.Value);
 /// <summary>Explicit conversion from Power.</summary>
 	public static explicit operator HeatFlowRate<T>(Power<T> value) => Create(value.Value);
 /// <summary>Creates a HeatFlowRate from a Power value.</summary>
 	public static HeatFlowRate<T> From(Power<T> value) => Create(value.Value);
+/// <summary>Subtracts two HeatFlowRate values, returning the absolute difference as a non-negative HeatFlowRate.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static HeatFlowRate<T> operator -(HeatFlowRate<T> left, HeatFlowRate<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HeatFlux.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HeatFlux.g.cs
@@ -19,12 +19,14 @@ public record HeatFlux<T> : PhysicalQuantity<HeatFlux<T>, T>, IVector0<HeatFlux<
 	public static HeatFlux<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new HeatFlux from a value in WattPerSquareMeter.</summary>
-	public static HeatFlux<T> FromWattPerSquareMeter(T value) => Create(value);
+	public static HeatFlux<T> FromWattPerSquareMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Irradiance.</summary>
 	public static implicit operator Irradiance<T>(HeatFlux<T> value) => Irradiance<T>.Create(value.Value);
 /// <summary>Explicit conversion from Irradiance.</summary>
 	public static explicit operator HeatFlux<T>(Irradiance<T> value) => Create(value.Value);
 /// <summary>Creates a HeatFlux from a Irradiance value.</summary>
 	public static HeatFlux<T> From(Irradiance<T> value) => Create(value.Value);
+/// <summary>Subtracts two HeatFlux values, returning the absolute difference as a non-negative HeatFlux.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static HeatFlux<T> operator -(HeatFlux<T> left, HeatFlux<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HeatTransferCoefficient.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HeatTransferCoefficient.g.cs
@@ -22,6 +22,12 @@ public record HeatTransferCoefficient<T> : PhysicalQuantity<HeatTransferCoeffici
 	/// </summary>
 	/// <param name="value">The value in WattPerSquareMeterKelvin.</param>
 	/// <returns>A new <see cref="HeatTransferCoefficient{T}"/> instance.</returns>
-	public static HeatTransferCoefficient<T> FromWattPerSquareMeterKelvin(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static HeatTransferCoefficient<T> FromWattPerSquareMeterKelvin(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two HeatTransferCoefficient values, returning the absolute difference as a non-negative HeatTransferCoefficient.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static HeatTransferCoefficient<T> operator -(HeatTransferCoefficient<T> left, HeatTransferCoefficient<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Height.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Height.g.cs
@@ -19,14 +19,14 @@ public record Height<T> : PhysicalQuantity<Height<T>, T>, IVector0<Height<T>, T>
 	public static Height<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Height from a value in Meter.</summary>
-	public static Height<T> FromMeter(T value) => Create(value);
+	public static Height<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Height<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>
 	public static explicit operator Height<T>(Length<T> value) => Create(value.Value);
 /// <summary>Creates a Height from a Length value.</summary>
 	public static Height<T> From(Length<T> value) => Create(value.Value);
-/// <summary>Subtracts two Height values, returning a signed Displacement1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Displacement1D<T> operator -(Height<T> left, Height<T> right) => Displacement1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Height values, returning the absolute difference as a non-negative Height.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Height<T> operator -(Height<T> left, Height<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Illuminance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Illuminance.g.cs
@@ -22,7 +22,13 @@ public record Illuminance<T> : PhysicalQuantity<Illuminance<T>, T>, IVector0<Ill
 	/// </summary>
 	/// <param name="value">The value in Lux.</param>
 	/// <returns>A new <see cref="Illuminance{T}"/> instance.</returns>
-	public static Illuminance<T> FromLux(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Illuminance<T> FromLux(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Illuminance values, returning the absolute difference as a non-negative Illuminance.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Illuminance<T> operator -(Illuminance<T> left, Illuminance<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Illuminance by Area to produce LuminousFlux.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Inductance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Inductance.g.cs
@@ -22,7 +22,13 @@ public record Inductance<T> : PhysicalQuantity<Inductance<T>, T>, IVector0<Induc
 	/// </summary>
 	/// <param name="value">The value in Henry.</param>
 	/// <returns>A new <see cref="Inductance{T}"/> instance.</returns>
-	public static Inductance<T> FromHenry(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Inductance<T> FromHenry(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Inductance values, returning the absolute difference as a non-negative Inductance.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Inductance<T> operator -(Inductance<T> left, Inductance<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Inductance by CurrentMagnitude to produce MagneticFlux.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Irradiance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Irradiance.g.cs
@@ -22,7 +22,13 @@ public record Irradiance<T> : PhysicalQuantity<Irradiance<T>, T>, IVector0<Irrad
 	/// </summary>
 	/// <param name="value">The value in WattPerSquareMeter.</param>
 	/// <returns>A new <see cref="Irradiance{T}"/> instance.</returns>
-	public static Irradiance<T> FromWattPerSquareMeter(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Irradiance<T> FromWattPerSquareMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Irradiance values, returning the absolute difference as a non-negative Irradiance.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Irradiance<T> operator -(Irradiance<T> left, Irradiance<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Irradiance by Area to produce Power.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/JerkMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/JerkMagnitude.g.cs
@@ -22,11 +22,13 @@ public record JerkMagnitude<T> : PhysicalQuantity<JerkMagnitude<T>, T>, IVector0
 	/// </summary>
 	/// <param name="value">The value in MetersPerSecondCubed.</param>
 	/// <returns>A new <see cref="JerkMagnitude{T}"/> instance.</returns>
-	public static JerkMagnitude<T> FromMetersPerSecondCubed(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static JerkMagnitude<T> FromMetersPerSecondCubed(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two JerkMagnitude values, returning a signed Jerk1D result.
+	/// Subtracts two JerkMagnitude values, returning the absolute difference as a non-negative JerkMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Jerk1D<T> operator -(JerkMagnitude<T> left, JerkMagnitude<T> right) => Jerk1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static JerkMagnitude<T> operator -(JerkMagnitude<T> left, JerkMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies JerkMagnitude by Duration to produce AccelerationMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/KinematicViscosity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/KinematicViscosity.g.cs
@@ -22,7 +22,13 @@ public record KinematicViscosity<T> : PhysicalQuantity<KinematicViscosity<T>, T>
 	/// </summary>
 	/// <param name="value">The value in SquareMeterPerSecond.</param>
 	/// <returns>A new <see cref="KinematicViscosity{T}"/> instance.</returns>
-	public static KinematicViscosity<T> FromSquareMeterPerSecond(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static KinematicViscosity<T> FromSquareMeterPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two KinematicViscosity values, returning the absolute difference as a non-negative KinematicViscosity.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static KinematicViscosity<T> operator -(KinematicViscosity<T> left, KinematicViscosity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies KinematicViscosity by Density to produce DynamicViscosity.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/KineticEnergy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/KineticEnergy.g.cs
@@ -19,12 +19,14 @@ public record KineticEnergy<T> : PhysicalQuantity<KineticEnergy<T>, T>, IVector0
 	public static KineticEnergy<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new KineticEnergy from a value in Joule.</summary>
-	public static KineticEnergy<T> FromJoule(T value) => Create(value);
+	public static KineticEnergy<T> FromJoule(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Energy.</summary>
 	public static implicit operator Energy<T>(KineticEnergy<T> value) => Energy<T>.Create(value.Value);
 /// <summary>Explicit conversion from Energy.</summary>
 	public static explicit operator KineticEnergy<T>(Energy<T> value) => Create(value.Value);
 /// <summary>Creates a KineticEnergy from a Energy value.</summary>
 	public static KineticEnergy<T> From(Energy<T> value) => Create(value.Value);
+/// <summary>Subtracts two KineticEnergy values, returning the absolute difference as a non-negative KineticEnergy.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static KineticEnergy<T> operator -(KineticEnergy<T> left, KineticEnergy<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Latency.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Latency.g.cs
@@ -19,12 +19,14 @@ public record Latency<T> : PhysicalQuantity<Latency<T>, T>, IVector0<Latency<T>,
 	public static Latency<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Latency from a value in Second.</summary>
-	public static Latency<T> FromSecond(T value) => Create(value);
+	public static Latency<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Duration.</summary>
 	public static implicit operator Duration<T>(Latency<T> value) => Duration<T>.Create(value.Value);
 /// <summary>Explicit conversion from Duration.</summary>
 	public static explicit operator Latency<T>(Duration<T> value) => Create(value.Value);
 /// <summary>Creates a Latency from a Duration value.</summary>
 	public static Latency<T> From(Duration<T> value) => Create(value.Value);
+/// <summary>Subtracts two Latency values, returning the absolute difference as a non-negative Latency.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Latency<T> operator -(Latency<T> left, Latency<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Length.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Length.g.cs
@@ -22,11 +22,13 @@ public record Length<T> : PhysicalQuantity<Length<T>, T>, IVector0<Length<T>, T>
 	/// </summary>
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new <see cref="Length{T}"/> instance.</returns>
-	public static Length<T> FromMeter(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Length<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two Length values, returning a signed Displacement1D result.
+	/// Subtracts two Length values, returning the absolute difference as a non-negative Length.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Displacement1D<T> operator -(Length<T> left, Length<T> right) => Displacement1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Length<T> operator -(Length<T> left, Length<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Length by Length to produce Area.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Lift.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Lift.g.cs
@@ -19,14 +19,14 @@ public record Lift<T> : PhysicalQuantity<Lift<T>, T>, IVector0<Lift<T>, T>
 	public static Lift<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Lift from a value in Newton.</summary>
-	public static Lift<T> FromNewton(T value) => Create(value);
+	public static Lift<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(Lift<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>
 	public static explicit operator Lift<T>(ForceMagnitude<T> value) => Create(value.Value);
 /// <summary>Creates a Lift from a ForceMagnitude value.</summary>
 	public static Lift<T> From(ForceMagnitude<T> value) => Create(value.Value);
-/// <summary>Subtracts two Lift values, returning a signed Force1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Force1D<T> operator -(Lift<T> left, Lift<T> right) => Force1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Lift values, returning the absolute difference as a non-negative Lift.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Lift<T> operator -(Lift<T> left, Lift<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Luminance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Luminance.g.cs
@@ -19,12 +19,14 @@ public record Luminance<T> : PhysicalQuantity<Luminance<T>, T>, IVector0<Luminan
 	public static Luminance<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Luminance from a value in Lux.</summary>
-	public static Luminance<T> FromLux(T value) => Create(value);
+	public static Luminance<T> FromLux(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Illuminance.</summary>
 	public static implicit operator Illuminance<T>(Luminance<T> value) => Illuminance<T>.Create(value.Value);
 /// <summary>Explicit conversion from Illuminance.</summary>
 	public static explicit operator Luminance<T>(Illuminance<T> value) => Create(value.Value);
 /// <summary>Creates a Luminance from a Illuminance value.</summary>
 	public static Luminance<T> From(Illuminance<T> value) => Create(value.Value);
+/// <summary>Subtracts two Luminance values, returning the absolute difference as a non-negative Luminance.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Luminance<T> operator -(Luminance<T> left, Luminance<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/LuminousFlux.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/LuminousFlux.g.cs
@@ -22,7 +22,13 @@ public record LuminousFlux<T> : PhysicalQuantity<LuminousFlux<T>, T>, IVector0<L
 	/// </summary>
 	/// <param name="value">The value in Lumen.</param>
 	/// <returns>A new <see cref="LuminousFlux{T}"/> instance.</returns>
-	public static LuminousFlux<T> FromLumen(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static LuminousFlux<T> FromLumen(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two LuminousFlux values, returning the absolute difference as a non-negative LuminousFlux.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static LuminousFlux<T> operator -(LuminousFlux<T> left, LuminousFlux<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides LuminousFlux by Area to produce Illuminance.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/LuminousIntensity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/LuminousIntensity.g.cs
@@ -22,6 +22,12 @@ public record LuminousIntensity<T> : PhysicalQuantity<LuminousIntensity<T>, T>, 
 	/// </summary>
 	/// <param name="value">The value in Candela.</param>
 	/// <returns>A new <see cref="LuminousIntensity{T}"/> instance.</returns>
-	public static LuminousIntensity<T> FromCandela(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static LuminousIntensity<T> FromCandela(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two LuminousIntensity values, returning the absolute difference as a non-negative LuminousIntensity.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static LuminousIntensity<T> operator -(LuminousIntensity<T> left, LuminousIntensity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MachNumber.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MachNumber.g.cs
@@ -19,14 +19,14 @@ public record MachNumber<T> : PhysicalQuantity<MachNumber<T>, T>, IVector0<MachN
 	public static MachNumber<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new MachNumber from a value in Dimensionless.</summary>
-	public static MachNumber<T> FromDimensionless(T value) => Create(value);
+	public static MachNumber<T> FromDimensionless(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Ratio.</summary>
 	public static implicit operator Ratio<T>(MachNumber<T> value) => Ratio<T>.Create(value.Value);
 /// <summary>Explicit conversion from Ratio.</summary>
 	public static explicit operator MachNumber<T>(Ratio<T> value) => Create(value.Value);
 /// <summary>Creates a MachNumber from a Ratio value.</summary>
 	public static MachNumber<T> From(Ratio<T> value) => Create(value.Value);
-/// <summary>Subtracts two MachNumber values, returning a signed SignedRatio result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SignedRatio<T> operator -(MachNumber<T> left, MachNumber<T> right) => SignedRatio<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two MachNumber values, returning the absolute difference as a non-negative MachNumber.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static MachNumber<T> operator -(MachNumber<T> left, MachNumber<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MagneticFlux.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MagneticFlux.g.cs
@@ -22,7 +22,13 @@ public record MagneticFlux<T> : PhysicalQuantity<MagneticFlux<T>, T>, IVector0<M
 	/// </summary>
 	/// <param name="value">The value in Weber.</param>
 	/// <returns>A new <see cref="MagneticFlux{T}"/> instance.</returns>
-	public static MagneticFlux<T> FromWeber(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MagneticFlux<T> FromWeber(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two MagneticFlux values, returning the absolute difference as a non-negative MagneticFlux.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static MagneticFlux<T> operator -(MagneticFlux<T> left, MagneticFlux<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides MagneticFlux by Area to produce MagneticFluxDensityMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MagneticFluxDensityMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MagneticFluxDensityMagnitude.g.cs
@@ -22,7 +22,13 @@ public record MagneticFluxDensityMagnitude<T> : PhysicalQuantity<MagneticFluxDen
 	/// </summary>
 	/// <param name="value">The value in Tesla.</param>
 	/// <returns>A new <see cref="MagneticFluxDensityMagnitude{T}"/> instance.</returns>
-	public static MagneticFluxDensityMagnitude<T> FromTesla(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MagneticFluxDensityMagnitude<T> FromTesla(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two MagneticFluxDensityMagnitude values, returning the absolute difference as a non-negative MagneticFluxDensityMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static MagneticFluxDensityMagnitude<T> operator -(MagneticFluxDensityMagnitude<T> left, MagneticFluxDensityMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies MagneticFluxDensityMagnitude by Area to produce MagneticFlux.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Mass.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Mass.g.cs
@@ -22,7 +22,13 @@ public record Mass<T> : PhysicalQuantity<Mass<T>, T>, IVector0<Mass<T>, T>
 	/// </summary>
 	/// <param name="value">The value in Kilogram.</param>
 	/// <returns>A new <see cref="Mass{T}"/> instance.</returns>
-	public static Mass<T> FromKilogram(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Mass<T> FromKilogram(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Mass values, returning the absolute difference as a non-negative Mass.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Mass<T> operator -(Mass<T> left, Mass<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Mass by AccelerationMagnitude to produce ForceMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MassFlowRate.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MassFlowRate.g.cs
@@ -22,7 +22,13 @@ public record MassFlowRate<T> : PhysicalQuantity<MassFlowRate<T>, T>, IVector0<M
 	/// </summary>
 	/// <param name="value">The value in KilogramPerSecond.</param>
 	/// <returns>A new <see cref="MassFlowRate{T}"/> instance.</returns>
-	public static MassFlowRate<T> FromKilogramPerSecond(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MassFlowRate<T> FromKilogramPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two MassFlowRate values, returning the absolute difference as a non-negative MassFlowRate.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static MassFlowRate<T> operator -(MassFlowRate<T> left, MassFlowRate<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies MassFlowRate by Duration to produce Mass.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MolarEnergy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MolarEnergy.g.cs
@@ -22,7 +22,13 @@ public record MolarEnergy<T> : PhysicalQuantity<MolarEnergy<T>, T>, IVector0<Mol
 	/// </summary>
 	/// <param name="value">The value in JoulePerMole.</param>
 	/// <returns>A new <see cref="MolarEnergy{T}"/> instance.</returns>
-	public static MolarEnergy<T> FromJoulePerMole(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MolarEnergy<T> FromJoulePerMole(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two MolarEnergy values, returning the absolute difference as a non-negative MolarEnergy.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static MolarEnergy<T> operator -(MolarEnergy<T> left, MolarEnergy<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies MolarEnergy by AmountOfSubstance to produce Energy.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MolarEnthalpy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MolarEnthalpy.g.cs
@@ -19,12 +19,14 @@ public record MolarEnthalpy<T> : PhysicalQuantity<MolarEnthalpy<T>, T>, IVector0
 	public static MolarEnthalpy<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new MolarEnthalpy from a value in JoulePerMole.</summary>
-	public static MolarEnthalpy<T> FromJoulePerMole(T value) => Create(value);
+	public static MolarEnthalpy<T> FromJoulePerMole(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to MolarEnergy.</summary>
 	public static implicit operator MolarEnergy<T>(MolarEnthalpy<T> value) => MolarEnergy<T>.Create(value.Value);
 /// <summary>Explicit conversion from MolarEnergy.</summary>
 	public static explicit operator MolarEnthalpy<T>(MolarEnergy<T> value) => Create(value.Value);
 /// <summary>Creates a MolarEnthalpy from a MolarEnergy value.</summary>
 	public static MolarEnthalpy<T> From(MolarEnergy<T> value) => Create(value.Value);
+/// <summary>Subtracts two MolarEnthalpy values, returning the absolute difference as a non-negative MolarEnthalpy.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static MolarEnthalpy<T> operator -(MolarEnthalpy<T> left, MolarEnthalpy<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MolarMass.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MolarMass.g.cs
@@ -22,7 +22,13 @@ public record MolarMass<T> : PhysicalQuantity<MolarMass<T>, T>, IVector0<MolarMa
 	/// </summary>
 	/// <param name="value">The value in KilogramPerMole.</param>
 	/// <returns>A new <see cref="MolarMass{T}"/> instance.</returns>
-	public static MolarMass<T> FromKilogramPerMole(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MolarMass<T> FromKilogramPerMole(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two MolarMass values, returning the absolute difference as a non-negative MolarMass.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static MolarMass<T> operator -(MolarMass<T> left, MolarMass<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies MolarMass by AmountOfSubstance to produce Mass.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MomentOfInertia.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MomentOfInertia.g.cs
@@ -22,7 +22,13 @@ public record MomentOfInertia<T> : PhysicalQuantity<MomentOfInertia<T>, T>, IVec
 	/// </summary>
 	/// <param name="value">The value in KilogramMeterSquared.</param>
 	/// <returns>A new <see cref="MomentOfInertia{T}"/> instance.</returns>
-	public static MomentOfInertia<T> FromKilogramMeterSquared(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MomentOfInertia<T> FromKilogramMeterSquared(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two MomentOfInertia values, returning the absolute difference as a non-negative MomentOfInertia.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static MomentOfInertia<T> operator -(MomentOfInertia<T> left, MomentOfInertia<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies MomentOfInertia by AngularSpeed to produce AngularMomentumMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MomentumMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MomentumMagnitude.g.cs
@@ -22,11 +22,13 @@ public record MomentumMagnitude<T> : PhysicalQuantity<MomentumMagnitude<T>, T>, 
 	/// </summary>
 	/// <param name="value">The value in NewtonSecond.</param>
 	/// <returns>A new <see cref="MomentumMagnitude{T}"/> instance.</returns>
-	public static MomentumMagnitude<T> FromNewtonSecond(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MomentumMagnitude<T> FromNewtonSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two MomentumMagnitude values, returning a signed Momentum1D result.
+	/// Subtracts two MomentumMagnitude values, returning the absolute difference as a non-negative MomentumMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Momentum1D<T> operator -(MomentumMagnitude<T> left, MomentumMagnitude<T> right) => Momentum1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static MomentumMagnitude<T> operator -(MomentumMagnitude<T> left, MomentumMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides MomentumMagnitude by Speed to produce Mass.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/NormalForce.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/NormalForce.g.cs
@@ -19,14 +19,14 @@ public record NormalForce<T> : PhysicalQuantity<NormalForce<T>, T>, IVector0<Nor
 	public static NormalForce<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new NormalForce from a value in Newton.</summary>
-	public static NormalForce<T> FromNewton(T value) => Create(value);
+	public static NormalForce<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(NormalForce<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>
 	public static explicit operator NormalForce<T>(ForceMagnitude<T> value) => Create(value.Value);
 /// <summary>Creates a NormalForce from a ForceMagnitude value.</summary>
 	public static NormalForce<T> From(ForceMagnitude<T> value) => Create(value.Value);
-/// <summary>Subtracts two NormalForce values, returning a signed Force1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Force1D<T> operator -(NormalForce<T> left, NormalForce<T> right) => Force1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two NormalForce values, returning the absolute difference as a non-negative NormalForce.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static NormalForce<T> operator -(NormalForce<T> left, NormalForce<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/NuclearCrossSection.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/NuclearCrossSection.g.cs
@@ -22,6 +22,12 @@ public record NuclearCrossSection<T> : PhysicalQuantity<NuclearCrossSection<T>, 
 	/// </summary>
 	/// <param name="value">The value in Barn.</param>
 	/// <returns>A new <see cref="NuclearCrossSection{T}"/> instance.</returns>
-	public static NuclearCrossSection<T> FromBarn(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static NuclearCrossSection<T> FromBarn(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two NuclearCrossSection values, returning the absolute difference as a non-negative NuclearCrossSection.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static NuclearCrossSection<T> operator -(NuclearCrossSection<T> left, NuclearCrossSection<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/OpticalPower.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/OpticalPower.g.cs
@@ -22,6 +22,12 @@ public record OpticalPower<T> : PhysicalQuantity<OpticalPower<T>, T>, IVector0<O
 	/// </summary>
 	/// <param name="value">The value in Diopter.</param>
 	/// <returns>A new <see cref="OpticalPower{T}"/> instance.</returns>
-	public static OpticalPower<T> FromDiopter(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static OpticalPower<T> FromDiopter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two OpticalPower values, returning the absolute difference as a non-negative OpticalPower.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static OpticalPower<T> operator -(OpticalPower<T> left, OpticalPower<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Perimeter.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Perimeter.g.cs
@@ -19,14 +19,14 @@ public record Perimeter<T> : PhysicalQuantity<Perimeter<T>, T>, IVector0<Perimet
 	public static Perimeter<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Perimeter from a value in Meter.</summary>
-	public static Perimeter<T> FromMeter(T value) => Create(value);
+	public static Perimeter<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Perimeter<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>
 	public static explicit operator Perimeter<T>(Length<T> value) => Create(value.Value);
 /// <summary>Creates a Perimeter from a Length value.</summary>
 	public static Perimeter<T> From(Length<T> value) => Create(value.Value);
-/// <summary>Subtracts two Perimeter values, returning a signed Displacement1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Displacement1D<T> operator -(Perimeter<T> left, Perimeter<T> right) => Displacement1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Perimeter values, returning the absolute difference as a non-negative Perimeter.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Perimeter<T> operator -(Perimeter<T> left, Perimeter<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Period.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Period.g.cs
@@ -19,12 +19,14 @@ public record Period<T> : PhysicalQuantity<Period<T>, T>, IVector0<Period<T>, T>
 	public static Period<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Period from a value in Second.</summary>
-	public static Period<T> FromSecond(T value) => Create(value);
+	public static Period<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Duration.</summary>
 	public static implicit operator Duration<T>(Period<T> value) => Duration<T>.Create(value.Value);
 /// <summary>Explicit conversion from Duration.</summary>
 	public static explicit operator Period<T>(Duration<T> value) => Create(value.Value);
 /// <summary>Creates a Period from a Duration value.</summary>
 	public static Period<T> From(Duration<T> value) => Create(value.Value);
+/// <summary>Subtracts two Period values, returning the absolute difference as a non-negative Period.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Period<T> operator -(Period<T> left, Period<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/PhaseVelocity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/PhaseVelocity.g.cs
@@ -19,14 +19,14 @@ public record PhaseVelocity<T> : PhysicalQuantity<PhaseVelocity<T>, T>, IVector0
 	public static PhaseVelocity<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new PhaseVelocity from a value in MetersPerSecond.</summary>
-	public static PhaseVelocity<T> FromMetersPerSecond(T value) => Create(value);
+	public static PhaseVelocity<T> FromMetersPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Speed.</summary>
 	public static implicit operator Speed<T>(PhaseVelocity<T> value) => Speed<T>.Create(value.Value);
 /// <summary>Explicit conversion from Speed.</summary>
 	public static explicit operator PhaseVelocity<T>(Speed<T> value) => Create(value.Value);
 /// <summary>Creates a PhaseVelocity from a Speed value.</summary>
 	public static PhaseVelocity<T> From(Speed<T> value) => Create(value.Value);
-/// <summary>Subtracts two PhaseVelocity values, returning a signed Velocity1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Velocity1D<T> operator -(PhaseVelocity<T> left, PhaseVelocity<T> right) => Velocity1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two PhaseVelocity values, returning the absolute difference as a non-negative PhaseVelocity.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static PhaseVelocity<T> operator -(PhaseVelocity<T> left, PhaseVelocity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Pitch.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Pitch.g.cs
@@ -19,12 +19,14 @@ public record Pitch<T> : PhysicalQuantity<Pitch<T>, T>, IVector0<Pitch<T>, T>
 	public static Pitch<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Pitch from a value in Hertz.</summary>
-	public static Pitch<T> FromHertz(T value) => Create(value);
+	public static Pitch<T> FromHertz(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Frequency.</summary>
 	public static implicit operator Frequency<T>(Pitch<T> value) => Frequency<T>.Create(value.Value);
 /// <summary>Explicit conversion from Frequency.</summary>
 	public static explicit operator Pitch<T>(Frequency<T> value) => Create(value.Value);
 /// <summary>Creates a Pitch from a Frequency value.</summary>
 	public static Pitch<T> From(Frequency<T> value) => Create(value.Value);
+/// <summary>Subtracts two Pitch values, returning the absolute difference as a non-negative Pitch.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Pitch<T> operator -(Pitch<T> left, Pitch<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/PotentialEnergy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/PotentialEnergy.g.cs
@@ -19,12 +19,14 @@ public record PotentialEnergy<T> : PhysicalQuantity<PotentialEnergy<T>, T>, IVec
 	public static PotentialEnergy<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new PotentialEnergy from a value in Joule.</summary>
-	public static PotentialEnergy<T> FromJoule(T value) => Create(value);
+	public static PotentialEnergy<T> FromJoule(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Energy.</summary>
 	public static implicit operator Energy<T>(PotentialEnergy<T> value) => Energy<T>.Create(value.Value);
 /// <summary>Explicit conversion from Energy.</summary>
 	public static explicit operator PotentialEnergy<T>(Energy<T> value) => Create(value.Value);
 /// <summary>Creates a PotentialEnergy from a Energy value.</summary>
 	public static PotentialEnergy<T> From(Energy<T> value) => Create(value.Value);
+/// <summary>Subtracts two PotentialEnergy values, returning the absolute difference as a non-negative PotentialEnergy.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static PotentialEnergy<T> operator -(PotentialEnergy<T> left, PotentialEnergy<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Power.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Power.g.cs
@@ -22,7 +22,13 @@ public record Power<T> : PhysicalQuantity<Power<T>, T>, IVector0<Power<T>, T>
 	/// </summary>
 	/// <param name="value">The value in Watt.</param>
 	/// <returns>A new <see cref="Power{T}"/> instance.</returns>
-	public static Power<T> FromWatt(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Power<T> FromWatt(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Power values, returning the absolute difference as a non-negative Power.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Power<T> operator -(Power<T> left, Power<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides Power by VoltageMagnitude to produce CurrentMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Pressure.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Pressure.g.cs
@@ -22,7 +22,13 @@ public record Pressure<T> : PhysicalQuantity<Pressure<T>, T>, IVector0<Pressure<
 	/// </summary>
 	/// <param name="value">The value in Pascal.</param>
 	/// <returns>A new <see cref="Pressure{T}"/> instance.</returns>
-	public static Pressure<T> FromPascal(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Pressure<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Pressure values, returning the absolute difference as a non-negative Pressure.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Pressure<T> operator -(Pressure<T> left, Pressure<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Pressure by Area to produce ForceMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/RadioactiveActivity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/RadioactiveActivity.g.cs
@@ -22,6 +22,12 @@ public record RadioactiveActivity<T> : PhysicalQuantity<RadioactiveActivity<T>, 
 	/// </summary>
 	/// <param name="value">The value in Becquerel.</param>
 	/// <returns>A new <see cref="RadioactiveActivity{T}"/> instance.</returns>
-	public static RadioactiveActivity<T> FromBecquerel(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static RadioactiveActivity<T> FromBecquerel(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two RadioactiveActivity values, returning the absolute difference as a non-negative RadioactiveActivity.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static RadioactiveActivity<T> operator -(RadioactiveActivity<T> left, RadioactiveActivity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Radius.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Radius.g.cs
@@ -19,14 +19,14 @@ public record Radius<T> : PhysicalQuantity<Radius<T>, T>, IVector0<Radius<T>, T>
 	public static Radius<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Radius from a value in Meter.</summary>
-	public static Radius<T> FromMeter(T value) => Create(value);
+	public static Radius<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Radius<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>
 	public static explicit operator Radius<T>(Length<T> value) => Create(value.Value);
 /// <summary>Creates a Radius from a Length value.</summary>
 	public static Radius<T> From(Length<T> value) => Create(value.Value);
-/// <summary>Subtracts two Radius values, returning a signed Displacement1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Displacement1D<T> operator -(Radius<T> left, Radius<T> right) => Displacement1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Radius values, returning the absolute difference as a non-negative Radius.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Radius<T> operator -(Radius<T> left, Radius<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Ratio.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Ratio.g.cs
@@ -22,11 +22,13 @@ public record Ratio<T> : PhysicalQuantity<Ratio<T>, T>, IVector0<Ratio<T>, T>
 	/// </summary>
 	/// <param name="value">The value in Dimensionless.</param>
 	/// <returns>A new <see cref="Ratio{T}"/> instance.</returns>
-	public static Ratio<T> FromDimensionless(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Ratio<T> FromDimensionless(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two Ratio values, returning a signed SignedRatio result.
+	/// Subtracts two Ratio values, returning the absolute difference as a non-negative Ratio.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SignedRatio<T> operator -(Ratio<T> left, Ratio<T> right) => SignedRatio<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Ratio<T> operator -(Ratio<T> left, Ratio<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides Ratio by Duration to produce Frequency.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReactionRate.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReactionRate.g.cs
@@ -22,7 +22,13 @@ public record ReactionRate<T> : PhysicalQuantity<ReactionRate<T>, T>, IVector0<R
 	/// </summary>
 	/// <param name="value">The value in MolePerCubicMeterSecond.</param>
 	/// <returns>A new <see cref="ReactionRate{T}"/> instance.</returns>
-	public static ReactionRate<T> FromMolePerCubicMeterSecond(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ReactionRate<T> FromMolePerCubicMeterSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two ReactionRate values, returning the absolute difference as a non-negative ReactionRate.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ReactionRate<T> operator -(ReactionRate<T> left, ReactionRate<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies ReactionRate by Duration to produce Concentration.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/RefractiveIndex.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/RefractiveIndex.g.cs
@@ -19,14 +19,14 @@ public record RefractiveIndex<T> : PhysicalQuantity<RefractiveIndex<T>, T>, IVec
 	public static RefractiveIndex<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new RefractiveIndex from a value in Dimensionless.</summary>
-	public static RefractiveIndex<T> FromDimensionless(T value) => Create(value);
+	public static RefractiveIndex<T> FromDimensionless(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Ratio.</summary>
 	public static implicit operator Ratio<T>(RefractiveIndex<T> value) => Ratio<T>.Create(value.Value);
 /// <summary>Explicit conversion from Ratio.</summary>
 	public static explicit operator RefractiveIndex<T>(Ratio<T> value) => Create(value.Value);
 /// <summary>Creates a RefractiveIndex from a Ratio value.</summary>
 	public static RefractiveIndex<T> From(Ratio<T> value) => Create(value.Value);
-/// <summary>Subtracts two RefractiveIndex values, returning a signed SignedRatio result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SignedRatio<T> operator -(RefractiveIndex<T> left, RefractiveIndex<T> right) => SignedRatio<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two RefractiveIndex values, returning the absolute difference as a non-negative RefractiveIndex.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static RefractiveIndex<T> operator -(RefractiveIndex<T> left, RefractiveIndex<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Resistance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Resistance.g.cs
@@ -22,7 +22,13 @@ public record Resistance<T> : PhysicalQuantity<Resistance<T>, T>, IVector0<Resis
 	/// </summary>
 	/// <param name="value">The value in Ohm.</param>
 	/// <returns>A new <see cref="Resistance{T}"/> instance.</returns>
-	public static Resistance<T> FromOhm(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Resistance<T> FromOhm(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Resistance values, returning the absolute difference as a non-negative Resistance.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Resistance<T> operator -(Resistance<T> left, Resistance<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Resistance by CurrentMagnitude to produce VoltageMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReverberationTime.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReverberationTime.g.cs
@@ -19,12 +19,14 @@ public record ReverberationTime<T> : PhysicalQuantity<ReverberationTime<T>, T>, 
 	public static ReverberationTime<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new ReverberationTime from a value in Second.</summary>
-	public static ReverberationTime<T> FromSecond(T value) => Create(value);
+	public static ReverberationTime<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Duration.</summary>
 	public static implicit operator Duration<T>(ReverberationTime<T> value) => Duration<T>.Create(value.Value);
 /// <summary>Explicit conversion from Duration.</summary>
 	public static explicit operator ReverberationTime<T>(Duration<T> value) => Create(value.Value);
 /// <summary>Creates a ReverberationTime from a Duration value.</summary>
 	public static ReverberationTime<T> From(Duration<T> value) => Create(value.Value);
+/// <summary>Subtracts two ReverberationTime values, returning the absolute difference as a non-negative ReverberationTime.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ReverberationTime<T> operator -(ReverberationTime<T> left, ReverberationTime<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReynoldsNumber.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReynoldsNumber.g.cs
@@ -19,14 +19,14 @@ public record ReynoldsNumber<T> : PhysicalQuantity<ReynoldsNumber<T>, T>, IVecto
 	public static ReynoldsNumber<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new ReynoldsNumber from a value in Dimensionless.</summary>
-	public static ReynoldsNumber<T> FromDimensionless(T value) => Create(value);
+	public static ReynoldsNumber<T> FromDimensionless(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Ratio.</summary>
 	public static implicit operator Ratio<T>(ReynoldsNumber<T> value) => Ratio<T>.Create(value.Value);
 /// <summary>Explicit conversion from Ratio.</summary>
 	public static explicit operator ReynoldsNumber<T>(Ratio<T> value) => Create(value.Value);
 /// <summary>Creates a ReynoldsNumber from a Ratio value.</summary>
 	public static ReynoldsNumber<T> From(Ratio<T> value) => Create(value.Value);
-/// <summary>Subtracts two ReynoldsNumber values, returning a signed SignedRatio result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SignedRatio<T> operator -(ReynoldsNumber<T> left, ReynoldsNumber<T> right) => SignedRatio<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two ReynoldsNumber values, returning the absolute difference as a non-negative ReynoldsNumber.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ReynoldsNumber<T> operator -(ReynoldsNumber<T> left, ReynoldsNumber<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SamplingRate.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SamplingRate.g.cs
@@ -19,12 +19,14 @@ public record SamplingRate<T> : PhysicalQuantity<SamplingRate<T>, T>, IVector0<S
 	public static SamplingRate<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new SamplingRate from a value in Hertz.</summary>
-	public static SamplingRate<T> FromHertz(T value) => Create(value);
+	public static SamplingRate<T> FromHertz(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Frequency.</summary>
 	public static implicit operator Frequency<T>(SamplingRate<T> value) => Frequency<T>.Create(value.Value);
 /// <summary>Explicit conversion from Frequency.</summary>
 	public static explicit operator SamplingRate<T>(Frequency<T> value) => Create(value.Value);
 /// <summary>Creates a SamplingRate from a Frequency value.</summary>
 	public static SamplingRate<T> From(Frequency<T> value) => Create(value.Value);
+/// <summary>Subtracts two SamplingRate values, returning the absolute difference as a non-negative SamplingRate.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SamplingRate<T> operator -(SamplingRate<T> left, SamplingRate<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ShearModulus.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ShearModulus.g.cs
@@ -19,12 +19,14 @@ public record ShearModulus<T> : PhysicalQuantity<ShearModulus<T>, T>, IVector0<S
 	public static ShearModulus<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new ShearModulus from a value in Pascal.</summary>
-	public static ShearModulus<T> FromPascal(T value) => Create(value);
+	public static ShearModulus<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Pressure.</summary>
 	public static implicit operator Pressure<T>(ShearModulus<T> value) => Pressure<T>.Create(value.Value);
 /// <summary>Explicit conversion from Pressure.</summary>
 	public static explicit operator ShearModulus<T>(Pressure<T> value) => Create(value.Value);
 /// <summary>Creates a ShearModulus from a Pressure value.</summary>
 	public static ShearModulus<T> From(Pressure<T> value) => Create(value.Value);
+/// <summary>Subtracts two ShearModulus values, returning the absolute difference as a non-negative ShearModulus.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ShearModulus<T> operator -(ShearModulus<T> left, ShearModulus<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SnapMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SnapMagnitude.g.cs
@@ -22,11 +22,13 @@ public record SnapMagnitude<T> : PhysicalQuantity<SnapMagnitude<T>, T>, IVector0
 	/// </summary>
 	/// <param name="value">The value in MetersPerSecondQuartic.</param>
 	/// <returns>A new <see cref="SnapMagnitude{T}"/> instance.</returns>
-	public static SnapMagnitude<T> FromMetersPerSecondQuartic(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SnapMagnitude<T> FromMetersPerSecondQuartic(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two SnapMagnitude values, returning a signed Snap1D result.
+	/// Subtracts two SnapMagnitude values, returning the absolute difference as a non-negative SnapMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Snap1D<T> operator -(SnapMagnitude<T> left, SnapMagnitude<T> right) => Snap1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SnapMagnitude<T> operator -(SnapMagnitude<T> left, SnapMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies SnapMagnitude by Duration to produce JerkMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SoundIntensity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SoundIntensity.g.cs
@@ -19,12 +19,14 @@ public record SoundIntensity<T> : PhysicalQuantity<SoundIntensity<T>, T>, IVecto
 	public static SoundIntensity<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new SoundIntensity from a value in WattPerSquareMeter.</summary>
-	public static SoundIntensity<T> FromWattPerSquareMeter(T value) => Create(value);
+	public static SoundIntensity<T> FromWattPerSquareMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Irradiance.</summary>
 	public static implicit operator Irradiance<T>(SoundIntensity<T> value) => Irradiance<T>.Create(value.Value);
 /// <summary>Explicit conversion from Irradiance.</summary>
 	public static explicit operator SoundIntensity<T>(Irradiance<T> value) => Create(value.Value);
 /// <summary>Creates a SoundIntensity from a Irradiance value.</summary>
 	public static SoundIntensity<T> From(Irradiance<T> value) => Create(value.Value);
+/// <summary>Subtracts two SoundIntensity values, returning the absolute difference as a non-negative SoundIntensity.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SoundIntensity<T> operator -(SoundIntensity<T> left, SoundIntensity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SoundSpeed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SoundSpeed.g.cs
@@ -19,14 +19,14 @@ public record SoundSpeed<T> : PhysicalQuantity<SoundSpeed<T>, T>, IVector0<Sound
 	public static SoundSpeed<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new SoundSpeed from a value in MetersPerSecond.</summary>
-	public static SoundSpeed<T> FromMetersPerSecond(T value) => Create(value);
+	public static SoundSpeed<T> FromMetersPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Speed.</summary>
 	public static implicit operator Speed<T>(SoundSpeed<T> value) => Speed<T>.Create(value.Value);
 /// <summary>Explicit conversion from Speed.</summary>
 	public static explicit operator SoundSpeed<T>(Speed<T> value) => Create(value.Value);
 /// <summary>Creates a SoundSpeed from a Speed value.</summary>
 	public static SoundSpeed<T> From(Speed<T> value) => Create(value.Value);
-/// <summary>Subtracts two SoundSpeed values, returning a signed Velocity1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Velocity1D<T> operator -(SoundSpeed<T> left, SoundSpeed<T> right) => Velocity1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two SoundSpeed values, returning the absolute difference as a non-negative SoundSpeed.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SoundSpeed<T> operator -(SoundSpeed<T> left, SoundSpeed<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SpecificEntropy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SpecificEntropy.g.cs
@@ -19,12 +19,14 @@ public record SpecificEntropy<T> : PhysicalQuantity<SpecificEntropy<T>, T>, IVec
 	public static SpecificEntropy<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new SpecificEntropy from a value in JoulePerKilogramKelvin.</summary>
-	public static SpecificEntropy<T> FromJoulePerKilogramKelvin(T value) => Create(value);
+	public static SpecificEntropy<T> FromJoulePerKilogramKelvin(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to SpecificHeat.</summary>
 	public static implicit operator SpecificHeat<T>(SpecificEntropy<T> value) => SpecificHeat<T>.Create(value.Value);
 /// <summary>Explicit conversion from SpecificHeat.</summary>
 	public static explicit operator SpecificEntropy<T>(SpecificHeat<T> value) => Create(value.Value);
 /// <summary>Creates a SpecificEntropy from a SpecificHeat value.</summary>
 	public static SpecificEntropy<T> From(SpecificHeat<T> value) => Create(value.Value);
+/// <summary>Subtracts two SpecificEntropy values, returning the absolute difference as a non-negative SpecificEntropy.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SpecificEntropy<T> operator -(SpecificEntropy<T> left, SpecificEntropy<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SpecificGravity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SpecificGravity.g.cs
@@ -19,14 +19,14 @@ public record SpecificGravity<T> : PhysicalQuantity<SpecificGravity<T>, T>, IVec
 	public static SpecificGravity<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new SpecificGravity from a value in Dimensionless.</summary>
-	public static SpecificGravity<T> FromDimensionless(T value) => Create(value);
+	public static SpecificGravity<T> FromDimensionless(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Ratio.</summary>
 	public static implicit operator Ratio<T>(SpecificGravity<T> value) => Ratio<T>.Create(value.Value);
 /// <summary>Explicit conversion from Ratio.</summary>
 	public static explicit operator SpecificGravity<T>(Ratio<T> value) => Create(value.Value);
 /// <summary>Creates a SpecificGravity from a Ratio value.</summary>
 	public static SpecificGravity<T> From(Ratio<T> value) => Create(value.Value);
-/// <summary>Subtracts two SpecificGravity values, returning a signed SignedRatio result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SignedRatio<T> operator -(SpecificGravity<T> left, SpecificGravity<T> right) => SignedRatio<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two SpecificGravity values, returning the absolute difference as a non-negative SpecificGravity.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SpecificGravity<T> operator -(SpecificGravity<T> left, SpecificGravity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SpecificHeat.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SpecificHeat.g.cs
@@ -22,7 +22,13 @@ public record SpecificHeat<T> : PhysicalQuantity<SpecificHeat<T>, T>, IVector0<S
 	/// </summary>
 	/// <param name="value">The value in JoulePerKilogramKelvin.</param>
 	/// <returns>A new <see cref="SpecificHeat{T}"/> instance.</returns>
-	public static SpecificHeat<T> FromJoulePerKilogramKelvin(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SpecificHeat<T> FromJoulePerKilogramKelvin(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two SpecificHeat values, returning the absolute difference as a non-negative SpecificHeat.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SpecificHeat<T> operator -(SpecificHeat<T> left, SpecificHeat<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies SpecificHeat by Mass to produce Entropy.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Speed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Speed.g.cs
@@ -22,11 +22,13 @@ public record Speed<T> : PhysicalQuantity<Speed<T>, T>, IVector0<Speed<T>, T>
 	/// </summary>
 	/// <param name="value">The value in MetersPerSecond.</param>
 	/// <returns>A new <see cref="Speed{T}"/> instance.</returns>
-	public static Speed<T> FromMetersPerSecond(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Speed<T> FromMetersPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two Speed values, returning a signed Velocity1D result.
+	/// Subtracts two Speed values, returning the absolute difference as a non-negative Speed.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Velocity1D<T> operator -(Speed<T> left, Speed<T> right) => Velocity1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Speed<T> operator -(Speed<T> left, Speed<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Speed by Mass to produce MomentumMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Stress.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Stress.g.cs
@@ -19,12 +19,14 @@ public record Stress<T> : PhysicalQuantity<Stress<T>, T>, IVector0<Stress<T>, T>
 	public static Stress<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Stress from a value in Pascal.</summary>
-	public static Stress<T> FromPascal(T value) => Create(value);
+	public static Stress<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Pressure.</summary>
 	public static implicit operator Pressure<T>(Stress<T> value) => Pressure<T>.Create(value.Value);
 /// <summary>Explicit conversion from Pressure.</summary>
 	public static explicit operator Stress<T>(Pressure<T> value) => Create(value.Value);
 /// <summary>Creates a Stress from a Pressure value.</summary>
 	public static Stress<T> From(Pressure<T> value) => Create(value.Value);
+/// <summary>Subtracts two Stress values, returning the absolute difference as a non-negative Stress.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Stress<T> operator -(Stress<T> left, Stress<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SurfaceArea.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SurfaceArea.g.cs
@@ -19,12 +19,14 @@ public record SurfaceArea<T> : PhysicalQuantity<SurfaceArea<T>, T>, IVector0<Sur
 	public static SurfaceArea<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new SurfaceArea from a value in SquareMeter.</summary>
-	public static SurfaceArea<T> FromSquareMeter(T value) => Create(value);
+	public static SurfaceArea<T> FromSquareMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Area.</summary>
 	public static implicit operator Area<T>(SurfaceArea<T> value) => Area<T>.Create(value.Value);
 /// <summary>Explicit conversion from Area.</summary>
 	public static explicit operator SurfaceArea<T>(Area<T> value) => Create(value.Value);
 /// <summary>Creates a SurfaceArea from a Area value.</summary>
 	public static SurfaceArea<T> From(Area<T> value) => Create(value.Value);
+/// <summary>Subtracts two SurfaceArea values, returning the absolute difference as a non-negative SurfaceArea.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SurfaceArea<T> operator -(SurfaceArea<T> left, SurfaceArea<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SurfaceTension.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SurfaceTension.g.cs
@@ -22,7 +22,13 @@ public record SurfaceTension<T> : PhysicalQuantity<SurfaceTension<T>, T>, IVecto
 	/// </summary>
 	/// <param name="value">The value in NewtonPerMeter.</param>
 	/// <returns>A new <see cref="SurfaceTension{T}"/> instance.</returns>
-	public static SurfaceTension<T> FromNewtonPerMeter(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SurfaceTension<T> FromNewtonPerMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two SurfaceTension values, returning the absolute difference as a non-negative SurfaceTension.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static SurfaceTension<T> operator -(SurfaceTension<T> left, SurfaceTension<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies SurfaceTension by Length to produce ForceMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Temperature.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Temperature.g.cs
@@ -22,11 +22,13 @@ public record Temperature<T> : PhysicalQuantity<Temperature<T>, T>, IVector0<Tem
 	/// </summary>
 	/// <param name="value">The value in Kelvin.</param>
 	/// <returns>A new <see cref="Temperature{T}"/> instance.</returns>
-	public static Temperature<T> FromKelvin(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Temperature<T> FromKelvin(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two Temperature values, returning a signed TemperatureDelta result.
+	/// Subtracts two Temperature values, returning the absolute difference as a non-negative Temperature.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static TemperatureDelta<T> operator -(Temperature<T> left, Temperature<T> right) => TemperatureDelta<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Temperature<T> operator -(Temperature<T> left, Temperature<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies Temperature by Entropy to produce Energy.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Tension.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Tension.g.cs
@@ -19,14 +19,14 @@ public record Tension<T> : PhysicalQuantity<Tension<T>, T>, IVector0<Tension<T>,
 	public static Tension<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Tension from a value in Newton.</summary>
-	public static Tension<T> FromNewton(T value) => Create(value);
+	public static Tension<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(Tension<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>
 	public static explicit operator Tension<T>(ForceMagnitude<T> value) => Create(value.Value);
 /// <summary>Creates a Tension from a ForceMagnitude value.</summary>
 	public static Tension<T> From(ForceMagnitude<T> value) => Create(value.Value);
-/// <summary>Subtracts two Tension values, returning a signed Force1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Force1D<T> operator -(Tension<T> left, Tension<T> right) => Force1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Tension values, returning the absolute difference as a non-negative Tension.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Tension<T> operator -(Tension<T> left, Tension<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ThermalConductivity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ThermalConductivity.g.cs
@@ -22,6 +22,12 @@ public record ThermalConductivity<T> : PhysicalQuantity<ThermalConductivity<T>, 
 	/// </summary>
 	/// <param name="value">The value in WattPerMeterKelvin.</param>
 	/// <returns>A new <see cref="ThermalConductivity{T}"/> instance.</returns>
-	public static ThermalConductivity<T> FromWattPerMeterKelvin(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ThermalConductivity<T> FromWattPerMeterKelvin(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two ThermalConductivity values, returning the absolute difference as a non-negative ThermalConductivity.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ThermalConductivity<T> operator -(ThermalConductivity<T> left, ThermalConductivity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ThermalDiffusivity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ThermalDiffusivity.g.cs
@@ -19,12 +19,14 @@ public record ThermalDiffusivity<T> : PhysicalQuantity<ThermalDiffusivity<T>, T>
 	public static ThermalDiffusivity<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new ThermalDiffusivity from a value in SquareMeterPerSecond.</summary>
-	public static ThermalDiffusivity<T> FromSquareMeterPerSecond(T value) => Create(value);
+	public static ThermalDiffusivity<T> FromSquareMeterPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to KinematicViscosity.</summary>
 	public static implicit operator KinematicViscosity<T>(ThermalDiffusivity<T> value) => KinematicViscosity<T>.Create(value.Value);
 /// <summary>Explicit conversion from KinematicViscosity.</summary>
 	public static explicit operator ThermalDiffusivity<T>(KinematicViscosity<T> value) => Create(value.Value);
 /// <summary>Creates a ThermalDiffusivity from a KinematicViscosity value.</summary>
 	public static ThermalDiffusivity<T> From(KinematicViscosity<T> value) => Create(value.Value);
+/// <summary>Subtracts two ThermalDiffusivity values, returning the absolute difference as a non-negative ThermalDiffusivity.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ThermalDiffusivity<T> operator -(ThermalDiffusivity<T> left, ThermalDiffusivity<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ThermalEnergy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ThermalEnergy.g.cs
@@ -19,12 +19,14 @@ public record ThermalEnergy<T> : PhysicalQuantity<ThermalEnergy<T>, T>, IVector0
 	public static ThermalEnergy<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new ThermalEnergy from a value in Joule.</summary>
-	public static ThermalEnergy<T> FromJoule(T value) => Create(value);
+	public static ThermalEnergy<T> FromJoule(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Energy.</summary>
 	public static implicit operator Energy<T>(ThermalEnergy<T> value) => Energy<T>.Create(value.Value);
 /// <summary>Explicit conversion from Energy.</summary>
 	public static explicit operator ThermalEnergy<T>(Energy<T> value) => Create(value.Value);
 /// <summary>Creates a ThermalEnergy from a Energy value.</summary>
 	public static ThermalEnergy<T> From(Energy<T> value) => Create(value.Value);
+/// <summary>Subtracts two ThermalEnergy values, returning the absolute difference as a non-negative ThermalEnergy.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ThermalEnergy<T> operator -(ThermalEnergy<T> left, ThermalEnergy<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ThermalExpansionCoefficient.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ThermalExpansionCoefficient.g.cs
@@ -22,7 +22,13 @@ public record ThermalExpansionCoefficient<T> : PhysicalQuantity<ThermalExpansion
 	/// </summary>
 	/// <param name="value">The value in PerKelvin.</param>
 	/// <returns>A new <see cref="ThermalExpansionCoefficient{T}"/> instance.</returns>
-	public static ThermalExpansionCoefficient<T> FromPerKelvin(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ThermalExpansionCoefficient<T> FromPerKelvin(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two ThermalExpansionCoefficient values, returning the absolute difference as a non-negative ThermalExpansionCoefficient.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static ThermalExpansionCoefficient<T> operator -(ThermalExpansionCoefficient<T> left, ThermalExpansionCoefficient<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies ThermalExpansionCoefficient by Temperature to produce Ratio.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Thickness.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Thickness.g.cs
@@ -19,14 +19,14 @@ public record Thickness<T> : PhysicalQuantity<Thickness<T>, T>, IVector0<Thickne
 	public static Thickness<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Thickness from a value in Meter.</summary>
-	public static Thickness<T> FromMeter(T value) => Create(value);
+	public static Thickness<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Thickness<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>
 	public static explicit operator Thickness<T>(Length<T> value) => Create(value.Value);
 /// <summary>Creates a Thickness from a Length value.</summary>
 	public static Thickness<T> From(Length<T> value) => Create(value.Value);
-/// <summary>Subtracts two Thickness values, returning a signed Displacement1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Displacement1D<T> operator -(Thickness<T> left, Thickness<T> right) => Displacement1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Thickness values, returning the absolute difference as a non-negative Thickness.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Thickness<T> operator -(Thickness<T> left, Thickness<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Thrust.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Thrust.g.cs
@@ -19,14 +19,14 @@ public record Thrust<T> : PhysicalQuantity<Thrust<T>, T>, IVector0<Thrust<T>, T>
 	public static Thrust<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Thrust from a value in Newton.</summary>
-	public static Thrust<T> FromNewton(T value) => Create(value);
+	public static Thrust<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(Thrust<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>
 	public static explicit operator Thrust<T>(ForceMagnitude<T> value) => Create(value.Value);
 /// <summary>Creates a Thrust from a ForceMagnitude value.</summary>
 	public static Thrust<T> From(ForceMagnitude<T> value) => Create(value.Value);
-/// <summary>Subtracts two Thrust values, returning a signed Force1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Force1D<T> operator -(Thrust<T> left, Thrust<T> right) => Force1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Thrust values, returning the absolute difference as a non-negative Thrust.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Thrust<T> operator -(Thrust<T> left, Thrust<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TimeConstant.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TimeConstant.g.cs
@@ -19,12 +19,14 @@ public record TimeConstant<T> : PhysicalQuantity<TimeConstant<T>, T>, IVector0<T
 	public static TimeConstant<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new TimeConstant from a value in Second.</summary>
-	public static TimeConstant<T> FromSecond(T value) => Create(value);
+	public static TimeConstant<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Duration.</summary>
 	public static implicit operator Duration<T>(TimeConstant<T> value) => Duration<T>.Create(value.Value);
 /// <summary>Explicit conversion from Duration.</summary>
 	public static explicit operator TimeConstant<T>(Duration<T> value) => Create(value.Value);
 /// <summary>Creates a TimeConstant from a Duration value.</summary>
 	public static TimeConstant<T> From(Duration<T> value) => Create(value.Value);
+/// <summary>Subtracts two TimeConstant values, returning the absolute difference as a non-negative TimeConstant.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static TimeConstant<T> operator -(TimeConstant<T> left, TimeConstant<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TorqueMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TorqueMagnitude.g.cs
@@ -22,11 +22,13 @@ public record TorqueMagnitude<T> : PhysicalQuantity<TorqueMagnitude<T>, T>, IVec
 	/// </summary>
 	/// <param name="value">The value in NewtonMeter.</param>
 	/// <returns>A new <see cref="TorqueMagnitude{T}"/> instance.</returns>
-	public static TorqueMagnitude<T> FromNewtonMeter(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static TorqueMagnitude<T> FromNewtonMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two TorqueMagnitude values, returning a signed Torque1D result.
+	/// Subtracts two TorqueMagnitude values, returning the absolute difference as a non-negative TorqueMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Torque1D<T> operator -(TorqueMagnitude<T> left, TorqueMagnitude<T> right) => Torque1D<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static TorqueMagnitude<T> operator -(TorqueMagnitude<T> left, TorqueMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies TorqueMagnitude by Angle to produce Energy.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VoltageDrop.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VoltageDrop.g.cs
@@ -19,14 +19,14 @@ public record VoltageDrop<T> : PhysicalQuantity<VoltageDrop<T>, T>, IVector0<Vol
 	public static VoltageDrop<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new VoltageDrop from a value in Volt.</summary>
-	public static VoltageDrop<T> FromVolt(T value) => Create(value);
+	public static VoltageDrop<T> FromVolt(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to VoltageMagnitude.</summary>
 	public static implicit operator VoltageMagnitude<T>(VoltageDrop<T> value) => VoltageMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from VoltageMagnitude.</summary>
 	public static explicit operator VoltageDrop<T>(VoltageMagnitude<T> value) => Create(value.Value);
 /// <summary>Creates a VoltageDrop from a VoltageMagnitude value.</summary>
 	public static VoltageDrop<T> From(VoltageMagnitude<T> value) => Create(value.Value);
-/// <summary>Subtracts two VoltageDrop values, returning a signed Voltage result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Voltage<T> operator -(VoltageDrop<T> left, VoltageDrop<T> right) => Voltage<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two VoltageDrop values, returning the absolute difference as a non-negative VoltageDrop.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static VoltageDrop<T> operator -(VoltageDrop<T> left, VoltageDrop<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VoltageMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VoltageMagnitude.g.cs
@@ -22,11 +22,13 @@ public record VoltageMagnitude<T> : PhysicalQuantity<VoltageMagnitude<T>, T>, IV
 	/// </summary>
 	/// <param name="value">The value in Volt.</param>
 	/// <returns>A new <see cref="VoltageMagnitude{T}"/> instance.</returns>
-	public static VoltageMagnitude<T> FromVolt(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static VoltageMagnitude<T> FromVolt(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
-	/// Subtracts two VoltageMagnitude values, returning a signed Voltage result.
+	/// Subtracts two VoltageMagnitude values, returning the absolute difference as a non-negative VoltageMagnitude.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
 	/// </summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Voltage<T> operator -(VoltageMagnitude<T> left, VoltageMagnitude<T> right) => Voltage<T>.Create(left.Quantity - right.Quantity);
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static VoltageMagnitude<T> operator -(VoltageMagnitude<T> left, VoltageMagnitude<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides VoltageMagnitude by Resistance to produce CurrentMagnitude.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Volume.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Volume.g.cs
@@ -22,7 +22,13 @@ public record Volume<T> : PhysicalQuantity<Volume<T>, T>, IVector0<Volume<T>, T>
 	/// </summary>
 	/// <param name="value">The value in CubicMeter.</param>
 	/// <returns>A new <see cref="Volume{T}"/> instance.</returns>
-	public static Volume<T> FromCubicMeter(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Volume<T> FromCubicMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two Volume values, returning the absolute difference as a non-negative Volume.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Volume<T> operator -(Volume<T> left, Volume<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Divides Volume by Length to produce Area.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VolumetricFlowRate.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VolumetricFlowRate.g.cs
@@ -22,7 +22,13 @@ public record VolumetricFlowRate<T> : PhysicalQuantity<VolumetricFlowRate<T>, T>
 	/// </summary>
 	/// <param name="value">The value in CubicMeterPerSecond.</param>
 	/// <returns>A new <see cref="VolumetricFlowRate{T}"/> instance.</returns>
-	public static VolumetricFlowRate<T> FromCubicMeterPerSecond(T value) => Create(value);
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static VolumetricFlowRate<T> FromCubicMeterPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+/// <summary>
+	/// Subtracts two VolumetricFlowRate values, returning the absolute difference as a non-negative VolumetricFlowRate.
+	/// Magnitude subtraction stays a magnitude (per the unified-vector model).
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static VolumetricFlowRate<T> operator -(VolumetricFlowRate<T> left, VolumetricFlowRate<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 /// <summary>
 	/// Multiplies VolumetricFlowRate by Duration to produce Volume.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Wavelength.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Wavelength.g.cs
@@ -19,14 +19,14 @@ public record Wavelength<T> : PhysicalQuantity<Wavelength<T>, T>, IVector0<Wavel
 	public static Wavelength<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Wavelength from a value in Meter.</summary>
-	public static Wavelength<T> FromMeter(T value) => Create(value);
+	public static Wavelength<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Wavelength<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>
 	public static explicit operator Wavelength<T>(Length<T> value) => Create(value.Value);
 /// <summary>Creates a Wavelength from a Length value.</summary>
 	public static Wavelength<T> From(Length<T> value) => Create(value.Value);
-/// <summary>Subtracts two Wavelength values, returning a signed Displacement1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Displacement1D<T> operator -(Wavelength<T> left, Wavelength<T> right) => Displacement1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Wavelength values, returning the absolute difference as a non-negative Wavelength.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Wavelength<T> operator -(Wavelength<T> left, Wavelength<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Weight.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Weight.g.cs
@@ -19,14 +19,14 @@ public record Weight<T> : PhysicalQuantity<Weight<T>, T>, IVector0<Weight<T>, T>
 	public static Weight<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Weight from a value in Newton.</summary>
-	public static Weight<T> FromNewton(T value) => Create(value);
+	public static Weight<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(Weight<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>
 	public static explicit operator Weight<T>(ForceMagnitude<T> value) => Create(value.Value);
 /// <summary>Creates a Weight from a ForceMagnitude value.</summary>
 	public static Weight<T> From(ForceMagnitude<T> value) => Create(value.Value);
-/// <summary>Subtracts two Weight values, returning a signed Force1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Force1D<T> operator -(Weight<T> left, Weight<T> right) => Force1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Weight values, returning the absolute difference as a non-negative Weight.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Weight<T> operator -(Weight<T> left, Weight<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Width.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Width.g.cs
@@ -19,14 +19,14 @@ public record Width<T> : PhysicalQuantity<Width<T>, T>, IVector0<Width<T>, T>
 	public static Width<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Width from a value in Meter.</summary>
-	public static Width<T> FromMeter(T value) => Create(value);
+	public static Width<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Width<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>
 	public static explicit operator Width<T>(Length<T> value) => Create(value.Value);
 /// <summary>Creates a Width from a Length value.</summary>
 	public static Width<T> From(Length<T> value) => Create(value.Value);
-/// <summary>Subtracts two Width values, returning a signed Displacement1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Displacement1D<T> operator -(Width<T> left, Width<T> right) => Displacement1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two Width values, returning the absolute difference as a non-negative Width.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Width<T> operator -(Width<T> left, Width<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/WindSpeed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/WindSpeed.g.cs
@@ -19,14 +19,14 @@ public record WindSpeed<T> : PhysicalQuantity<WindSpeed<T>, T>, IVector0<WindSpe
 	public static WindSpeed<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new WindSpeed from a value in MetersPerSecond.</summary>
-	public static WindSpeed<T> FromMetersPerSecond(T value) => Create(value);
+	public static WindSpeed<T> FromMetersPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Speed.</summary>
 	public static implicit operator Speed<T>(WindSpeed<T> value) => Speed<T>.Create(value.Value);
 /// <summary>Explicit conversion from Speed.</summary>
 	public static explicit operator WindSpeed<T>(Speed<T> value) => Create(value.Value);
 /// <summary>Creates a WindSpeed from a Speed value.</summary>
 	public static WindSpeed<T> From(Speed<T> value) => Create(value.Value);
-/// <summary>Subtracts two WindSpeed values, returning a signed Velocity1D result.</summary>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Velocity1D<T> operator -(WindSpeed<T> left, WindSpeed<T> right) => Velocity1D<T>.Create(left.Quantity - right.Quantity);
+/// <summary>Subtracts two WindSpeed values, returning the absolute difference as a non-negative WindSpeed.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static WindSpeed<T> operator -(WindSpeed<T> left, WindSpeed<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Work.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Work.g.cs
@@ -19,12 +19,14 @@ public record Work<T> : PhysicalQuantity<Work<T>, T>, IVector0<Work<T>, T>
 	public static Work<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new Work from a value in Joule.</summary>
-	public static Work<T> FromJoule(T value) => Create(value);
+	public static Work<T> FromJoule(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Energy.</summary>
 	public static implicit operator Energy<T>(Work<T> value) => Energy<T>.Create(value.Value);
 /// <summary>Explicit conversion from Energy.</summary>
 	public static explicit operator Work<T>(Energy<T> value) => Create(value.Value);
 /// <summary>Creates a Work from a Energy value.</summary>
 	public static Work<T> From(Energy<T> value) => Create(value.Value);
+/// <summary>Subtracts two Work values, returning the absolute difference as a non-negative Work.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static Work<T> operator -(Work<T> left, Work<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/YoungsModulus.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/YoungsModulus.g.cs
@@ -19,12 +19,14 @@ public record YoungsModulus<T> : PhysicalQuantity<YoungsModulus<T>, T>, IVector0
 	public static YoungsModulus<T> Zero => Create(T.Zero);
 
 	/// <summary>Creates a new YoungsModulus from a value in Pascal.</summary>
-	public static YoungsModulus<T> FromPascal(T value) => Create(value);
+	public static YoungsModulus<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to Pressure.</summary>
 	public static implicit operator Pressure<T>(YoungsModulus<T> value) => Pressure<T>.Create(value.Value);
 /// <summary>Explicit conversion from Pressure.</summary>
 	public static explicit operator YoungsModulus<T>(Pressure<T> value) => Create(value.Value);
 /// <summary>Creates a YoungsModulus from a Pressure value.</summary>
 	public static YoungsModulus<T> From(Pressure<T> value) => Create(value.Value);
+/// <summary>Subtracts two YoungsModulus values, returning the absolute difference as a non-negative YoungsModulus.</summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Physics quantity operator")] public static YoungsModulus<T> operator -(YoungsModulus<T> left, YoungsModulus<T> right) => Create(T.Abs(left.Quantity - right.Quantity));
 };
 

--- a/Semantics.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/Semantics.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/Semantics.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/Semantics.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,9 @@
+; Unshipped analyzer release.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+SEM001  | Semantics.SourceGenerators | Warning | Reports relationships in dimensions.json that reference unknown dimension names.
+SEM002  | Semantics.SourceGenerators | Warning | Reports schema-level validation issues in dimensions.json (missing fields, duplicate type names, etc).

--- a/Semantics.SourceGenerators/Generators/QuantitiesGenerator.cs
+++ b/Semantics.SourceGenerators/Generators/QuantitiesGenerator.cs
@@ -28,6 +28,14 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 		defaultSeverity: DiagnosticSeverity.Warning,
 		isEnabledByDefault: true);
 
+	private static readonly DiagnosticDescriptor MetadataValidationFailed = new(
+		id: "SEM002",
+		title: "dimensions.json metadata validation failed",
+		messageFormat: "dimensions.json validation issue: {0}",
+		category: "Semantics.SourceGenerators",
+		defaultSeverity: DiagnosticSeverity.Warning,
+		isEnabledByDefault: true);
+
 	public QuantitiesGenerator() : base("dimensions.json") { }
 
 	protected override void Generate(SourceProductionContext context, DimensionsMetadata metadata, CodeBlocker codeBlocker)
@@ -35,6 +43,17 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 		if (metadata.PhysicalDimensions == null || metadata.PhysicalDimensions.Count == 0)
 		{
 			return;
+		}
+
+		// Issue #60: surface schema-level metadata problems as diagnostics so they
+		// show up in the build log instead of crashing mid-emit.
+		List<string> validationIssues = metadata.Validate();
+		foreach (string issue in validationIssues)
+		{
+			context.ReportDiagnostic(Diagnostic.Create(
+				MetadataValidationFailed,
+				Location.None,
+				issue));
 		}
 
 		// Phase A: Build maps and collect operators

--- a/Semantics.SourceGenerators/Models/DimensionsMetadata.cs
+++ b/Semantics.SourceGenerators/Models/DimensionsMetadata.cs
@@ -12,6 +12,112 @@ using System.Collections.Generic;
 public class DimensionsMetadata
 {
 	public List<PhysicalDimension> PhysicalDimensions { get; set; } = [];
+
+	/// <summary>
+	/// Validates the deserialised metadata, returning a list of human-readable issues.
+	/// An empty list means the metadata is well-formed.
+	/// </summary>
+	/// <remarks>
+	/// Per #60: catches malformed entries before they reach the generator emit
+	/// pass, so problems surface as Roslyn diagnostics rather than a mid-emit crash
+	/// or a silently dropped operator. Cross-dimension reference checks are still
+	/// performed in the generator (#56 / SEM001) because they need the full
+	/// dimension map.
+	/// </remarks>
+	public List<string> Validate()
+	{
+		List<string> issues = [];
+
+		if (PhysicalDimensions.Count == 0)
+		{
+			issues.Add("dimensions.json contains no physicalDimensions entries.");
+			return issues;
+		}
+
+		HashSet<string> seenDimensionNames = [];
+		HashSet<string> seenTypeNames = [];
+
+		foreach (PhysicalDimension dim in PhysicalDimensions)
+		{
+			string label = string.IsNullOrEmpty(dim.Name) ? "<unnamed>" : dim.Name;
+
+			if (string.IsNullOrEmpty(dim.Name))
+			{
+				issues.Add("A physicalDimensions entry is missing 'name'.");
+			}
+			else if (!seenDimensionNames.Add(dim.Name))
+			{
+				issues.Add($"Dimension '{dim.Name}' is declared more than once.");
+			}
+
+			if (string.IsNullOrEmpty(dim.Symbol))
+			{
+				issues.Add($"Dimension '{label}' is missing 'symbol'.");
+			}
+
+			if (dim.AvailableUnits.Count == 0)
+			{
+				issues.Add($"Dimension '{label}' has an empty 'availableUnits' list.");
+			}
+			else
+			{
+				foreach (string unit in dim.AvailableUnits)
+				{
+					if (string.IsNullOrWhiteSpace(unit))
+					{
+						issues.Add($"Dimension '{label}' has a blank entry in 'availableUnits'.");
+					}
+				}
+			}
+
+			VectorFormDefinition?[] forms = [
+				dim.Quantities.Vector0,
+				dim.Quantities.Vector1,
+				dim.Quantities.Vector2,
+				dim.Quantities.Vector3,
+				dim.Quantities.Vector4,
+			];
+
+			if (System.Array.TrueForAll(forms, f => f == null))
+			{
+				issues.Add($"Dimension '{label}' declares no vector forms (vector0..vector4).");
+			}
+
+			for (int i = 0; i < forms.Length; i++)
+			{
+				VectorFormDefinition? form = forms[i];
+				if (form == null)
+				{
+					continue;
+				}
+
+				if (string.IsNullOrEmpty(form.Base))
+				{
+					issues.Add($"Dimension '{label}' vector{i} is missing 'base'.");
+				}
+				else if (!seenTypeNames.Add(form.Base))
+				{
+					issues.Add($"Type name '{form.Base}' (dimension '{label}' vector{i}) collides with another base or overload.");
+				}
+
+				foreach (OverloadDefinition overload in form.Overloads)
+				{
+					if (string.IsNullOrEmpty(overload.Name))
+					{
+						issues.Add($"Dimension '{label}' vector{i} has an overload missing 'name'.");
+						continue;
+					}
+
+					if (!seenTypeNames.Add(overload.Name))
+					{
+						issues.Add($"Overload type name '{overload.Name}' (dimension '{label}' vector{i}) collides with another base or overload.");
+					}
+				}
+			}
+		}
+
+		return issues;
+	}
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Continues the vectors-branch cleanup. Pulls in three things:

1. **Closes #60 — schema validation for `dimensions.json`.** Adds `DimensionsMetadata.Validate()` and a new Roslyn diagnostic `SEM002` so malformed metadata (missing `name`/`symbol`, empty `availableUnits`, duplicate type names, no vector forms declared) is reported in the build log instead of crashing mid-emit or silently dropping output. Pairs with the existing `SEM001` from #65.
2. **Fixes a pre-existing build failure.** Adds `AnalyzerReleases.Shipped.md` / `AnalyzerReleases.Unshipped.md` so `SEM001`/`SEM002` satisfy `RS2008` analyzer release tracking. The source-generator project now builds clean.
3. **Refreshes stale committed generator output.** The 132 `*.g.cs` files under `Semantics.Quantities/Generated/` were not re-emitted after the V0 non-negativity / absolute V0–V0 subtraction work landed in #66/#68. Re-running the generator updates each Vector0 type's `From{Unit}` factory to call `Vector0Guards.EnsureNonNegative` and replaces the V1-typed subtraction operator with the documented same-type `T.Abs(a − b)`. Per CLAUDE.md generator output is committed source, so this needed to be in-tree.
4. **Doc tidying for #61.** CLAUDE.md's V0 invariant section now describes what's actually enforced (structural, via `Vector0Guards`) and the `PhysicalConstants` example matches the real generated surface (no `Conversion` sub-class). Adds a SEM00x diagnostics list to the generator workflow section.

Status of the rest of the open issues on the branch is summarised in follow-up comments on each issue.

## Test plan

- [x] `dotnet build Semantics.SourceGenerators` — clean
- [x] `dotnet build Semantics.Quantities` — generator runs cleanly, no `SEM001`/`SEM002` warnings against the current `dimensions.json`, and the only diff against the committed `Generated/` tree is the documented #50/#52 update.
- [ ] `dotnet test` — `Semantics.Test` cannot restore in this sandbox (`Microsoft.NETCore.App.Host.ubuntu.24.04-x64` is not in the configured feeds); existing `Vector0InvariantTests` already cover the regenerated factory and operator behaviour.

https://claude.ai/code/session_01Tj63Rddvs9frqLUgsjNEP5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tj63Rddvs9frqLUgsjNEP5)_