### PR TITLE
feat(generator): plural From{Unit} factory naming + form matrix docs (closes #49, partial #58)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ var converted = sourceString.As<SourceType, TargetType>();
 - Edit `Semantics.SourceGenerators/Metadata/dimensions.json` to add a dimension, vector form, semantic overload, or relationship.
 - Rebuild `Semantics.SourceGenerators` and the consuming `Semantics.Quantities` project; emitted files appear in `Semantics.Quantities/Generated/Semantics.SourceGenerators/<GeneratorName>/`.
 - Treat generator output as committed source. Diff it before commit so accidental regressions are visible.
+- Factory names are **plural by convention** (#49). Each entry in `units.json` carries a `factoryName` field — the generator emits `From{factoryName}` (e.g. `Length.FromMeters`, `Mass.FromKilograms`, `Speed.FromMetersPerSecond`, `Length.FromFeet`, `Frequency.FromHertz`). Set it explicitly on every new unit; the generator falls back to `name + "s"` if absent, which is wrong for irregulars and "Per" compounds.
 - Generator diagnostics:
   - **SEM001** — a relationship in `dimensions.json` references a dimension that does not exist (typo or rename). The operator is silently dropped.
   - **SEM002** — schema-level validation issue (missing `name`/`symbol`, empty `availableUnits`, duplicate type names, no vector forms declared).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AbsorbedDose.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AbsorbedDose.g.cs
@@ -23,7 +23,7 @@ public record AbsorbedDose<T> : PhysicalQuantity<AbsorbedDose<T>, T>, IVector0<A
 	/// <param name="value">The value in Gray.</param>
 	/// <returns>A new <see cref="AbsorbedDose{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static AbsorbedDose<T> FromGray(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static AbsorbedDose<T> FromGrays(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two AbsorbedDose values, returning the absolute difference as a non-negative AbsorbedDose.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Altitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Altitude.g.cs
@@ -24,77 +24,77 @@ public record Altitude<T> : PhysicalQuantity<Altitude<T>, T>, IVector0<Altitude<
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new Altitude instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Altitude<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Altitude<T> FromMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Altitude from a value in Kilometer.
 	/// </summary>
 	/// <param name="value">The value in Kilometer.</param>
 	/// <returns>A new Altitude instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Altitude<T> FromKilometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+	public static Altitude<T> FromKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
 /// <summary>
 	/// Creates a new Altitude from a value in Centimeter.
 	/// </summary>
 	/// <param name="value">The value in Centimeter.</param>
 	/// <returns>A new Altitude instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Altitude<T> FromCentimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
+	public static Altitude<T> FromCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
 /// <summary>
 	/// Creates a new Altitude from a value in Millimeter.
 	/// </summary>
 	/// <param name="value">The value in Millimeter.</param>
 	/// <returns>A new Altitude instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Altitude<T> FromMillimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Altitude<T> FromMillimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new Altitude from a value in Micrometer.
 	/// </summary>
 	/// <param name="value">The value in Micrometer.</param>
 	/// <returns>A new Altitude instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Altitude<T> FromMicrometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Altitude<T> FromMicrometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new Altitude from a value in Nanometer.
 	/// </summary>
 	/// <param name="value">The value in Nanometer.</param>
 	/// <returns>A new Altitude instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Altitude<T> FromNanometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+	public static Altitude<T> FromNanometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
 /// <summary>
 	/// Creates a new Altitude from a value in Angstrom.
 	/// </summary>
 	/// <param name="value">The value in Angstrom.</param>
 	/// <returns>A new Altitude instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Altitude<T> FromAngstrom(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
+	public static Altitude<T> FromAngstroms(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Altitude from a value in Foot.
 	/// </summary>
 	/// <param name="value">The value in Foot.</param>
 	/// <returns>A new Altitude instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Altitude<T> FromFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
+	public static Altitude<T> FromFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Altitude from a value in Inch.
 	/// </summary>
 	/// <param name="value">The value in Inch.</param>
 	/// <returns>A new Altitude instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Altitude<T> FromInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
+	public static Altitude<T> FromInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Altitude from a value in Yard.
 	/// </summary>
 	/// <param name="value">The value in Yard.</param>
 	/// <returns>A new Altitude instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Altitude<T> FromYard(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
+	public static Altitude<T> FromYards(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Altitude from a value in Mile.
 	/// </summary>
 	/// <param name="value">The value in Mile.</param>
 	/// <returns>A new Altitude instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Altitude<T> FromMile(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
+	public static Altitude<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Altitude<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AmountOfSubstance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AmountOfSubstance.g.cs
@@ -23,7 +23,7 @@ public record AmountOfSubstance<T> : PhysicalQuantity<AmountOfSubstance<T>, T>, 
 	/// <param name="value">The value in Mole.</param>
 	/// <returns>A new <see cref="AmountOfSubstance{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static AmountOfSubstance<T> FromMole(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static AmountOfSubstance<T> FromMoles(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two AmountOfSubstance values, returning the absolute difference as a non-negative AmountOfSubstance.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Angle.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Angle.g.cs
@@ -23,14 +23,14 @@ public record Angle<T> : PhysicalQuantity<Angle<T>, T>, IVector0<Angle<T>, T>
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new <see cref="Angle{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Angle<T> FromRadian(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Angle<T> FromRadians(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Angle{T}"/> from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new <see cref="Angle{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Angle<T> FromDegree(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
+	public static Angle<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>
 	/// Subtracts two Angle values, returning the absolute difference as a non-negative Angle.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ApertureAngle.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ApertureAngle.g.cs
@@ -24,14 +24,14 @@ public record ApertureAngle<T> : PhysicalQuantity<ApertureAngle<T>, T>, IVector0
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new ApertureAngle instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ApertureAngle<T> FromRadian(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static ApertureAngle<T> FromRadians(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new ApertureAngle from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new ApertureAngle instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ApertureAngle<T> FromDegree(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
+	public static ApertureAngle<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>Implicit conversion to Angle.</summary>
 	public static implicit operator Angle<T>(ApertureAngle<T> value) => Angle<T>.Create(value.Value);
 /// <summary>Explicit conversion from Angle.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Area.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Area.g.cs
@@ -23,21 +23,21 @@ public record Area<T> : PhysicalQuantity<Area<T>, T>, IVector0<Area<T>, T>
 	/// <param name="value">The value in SquareMeter.</param>
 	/// <returns>A new <see cref="Area{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Area<T> FromSquareMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Area<T> FromSquareMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Area{T}"/> from a value in SquareFoot.
 	/// </summary>
 	/// <param name="value">The value in SquareFoot.</param>
 	/// <returns>A new <see cref="Area{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Area<T> FromSquareFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareFootToSquareMeters)), nameof(value)));
+	public static Area<T> FromSquareFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareFootToSquareMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Area{T}"/> from a value in SquareInch.
 	/// </summary>
 	/// <param name="value">The value in SquareInch.</param>
 	/// <returns>A new <see cref="Area{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Area<T> FromSquareInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareInchToSquareMeters)), nameof(value)));
+	public static Area<T> FromSquareInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareInchToSquareMeters)), nameof(value)));
 /// <summary>
 	/// Subtracts two Area values, returning the absolute difference as a non-negative Area.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AtmosphericPressure.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AtmosphericPressure.g.cs
@@ -24,21 +24,21 @@ public record AtmosphericPressure<T> : PhysicalQuantity<AtmosphericPressure<T>, 
 	/// <param name="value">The value in Pascal.</param>
 	/// <returns>A new AtmosphericPressure instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static AtmosphericPressure<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static AtmosphericPressure<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new AtmosphericPressure from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
 	/// <returns>A new AtmosphericPressure instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static AtmosphericPressure<T> FromBar(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
+	public static AtmosphericPressure<T> FromBars(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new AtmosphericPressure from a value in Atmosphere.
 	/// </summary>
 	/// <param name="value">The value in Atmosphere.</param>
 	/// <returns>A new AtmosphericPressure instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static AtmosphericPressure<T> FromAtmosphere(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
+	public static AtmosphericPressure<T> FromAtmospheres(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new AtmosphericPressure from a value in Psi.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AtomicMass.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AtomicMass.g.cs
@@ -24,35 +24,35 @@ public record AtomicMass<T> : PhysicalQuantity<AtomicMass<T>, T>, IVector0<Atomi
 	/// <param name="value">The value in Kilogram.</param>
 	/// <returns>A new AtomicMass instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static AtomicMass<T> FromKilogram(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static AtomicMass<T> FromKilograms(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new AtomicMass from a value in Gram.
 	/// </summary>
 	/// <param name="value">The value in Gram.</param>
 	/// <returns>A new AtomicMass instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static AtomicMass<T> FromGram(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static AtomicMass<T> FromGrams(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new AtomicMass from a value in Ton.
 	/// </summary>
 	/// <param name="value">The value in Ton.</param>
 	/// <returns>A new AtomicMass instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static AtomicMass<T> FromTon(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.TonToKilograms)), nameof(value)));
+	public static AtomicMass<T> FromTons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.TonToKilograms)), nameof(value)));
 /// <summary>
 	/// Creates a new AtomicMass from a value in Pound.
 	/// </summary>
 	/// <param name="value">The value in Pound.</param>
 	/// <returns>A new AtomicMass instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static AtomicMass<T> FromPound(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundToKilograms)), nameof(value)));
+	public static AtomicMass<T> FromPounds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundToKilograms)), nameof(value)));
 /// <summary>
 	/// Creates a new AtomicMass from a value in Ounce.
 	/// </summary>
 	/// <param name="value">The value in Ounce.</param>
 	/// <returns>A new AtomicMass instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static AtomicMass<T> FromOunce(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.OunceToKilograms)), nameof(value)));
+	public static AtomicMass<T> FromOunces(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.OunceToKilograms)), nameof(value)));
 /// <summary>Implicit conversion to Mass.</summary>
 	public static implicit operator Mass<T>(AtomicMass<T> value) => Mass<T>.Create(value.Value);
 /// <summary>Explicit conversion from Mass.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Bearing.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Bearing.g.cs
@@ -23,13 +23,13 @@ public record Bearing<T> : PhysicalQuantity<Bearing<T>, T>, IVector1<Bearing<T>,
 	/// </summary>
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new Bearing instance.</returns>
-	public static Bearing<T> FromRadian(T value) => Create(value);
+	public static Bearing<T> FromRadians(T value) => Create(value);
 /// <summary>
 	/// Creates a new Bearing from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new Bearing instance.</returns>
-	public static Bearing<T> FromDegree(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
+	public static Bearing<T> FromDegrees(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
 /// <summary>Implicit conversion to SignedAngle.</summary>
 	public static implicit operator SignedAngle<T>(Bearing<T> value) => SignedAngle<T>.Create(value.Value);
 /// <summary>Explicit conversion from SignedAngle.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/BulkModulus.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/BulkModulus.g.cs
@@ -24,21 +24,21 @@ public record BulkModulus<T> : PhysicalQuantity<BulkModulus<T>, T>, IVector0<Bul
 	/// <param name="value">The value in Pascal.</param>
 	/// <returns>A new BulkModulus instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static BulkModulus<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static BulkModulus<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new BulkModulus from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
 	/// <returns>A new BulkModulus instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static BulkModulus<T> FromBar(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
+	public static BulkModulus<T> FromBars(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new BulkModulus from a value in Atmosphere.
 	/// </summary>
 	/// <param name="value">The value in Atmosphere.</param>
 	/// <returns>A new BulkModulus instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static BulkModulus<T> FromAtmosphere(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
+	public static BulkModulus<T> FromAtmospheres(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new BulkModulus from a value in Psi.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Capacitance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Capacitance.g.cs
@@ -23,7 +23,7 @@ public record Capacitance<T> : PhysicalQuantity<Capacitance<T>, T>, IVector0<Cap
 	/// <param name="value">The value in Farad.</param>
 	/// <returns>A new <see cref="Capacitance{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Capacitance<T> FromFarad(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Capacitance<T> FromFarads(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two Capacitance values, returning the absolute difference as a non-negative Capacitance.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Capacity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Capacity.g.cs
@@ -24,28 +24,28 @@ public record Capacity<T> : PhysicalQuantity<Capacity<T>, T>, IVector0<Capacity<
 	/// <param name="value">The value in CubicMeter.</param>
 	/// <returns>A new Capacity instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Capacity<T> FromCubicMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Capacity<T> FromCubicMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Capacity from a value in Liter.
 	/// </summary>
 	/// <param name="value">The value in Liter.</param>
 	/// <returns>A new Capacity instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Capacity<T> FromLiter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.LiterToCubicMeters)), nameof(value)));
+	public static Capacity<T> FromLiters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.LiterToCubicMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Capacity from a value in Milliliter.
 	/// </summary>
 	/// <param name="value">The value in Milliliter.</param>
 	/// <returns>A new Capacity instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Capacity<T> FromMilliliter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Capacity<T> FromMilliliters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new Capacity from a value in Gallon.
 	/// </summary>
 	/// <param name="value">The value in Gallon.</param>
 	/// <returns>A new Capacity instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Capacity<T> FromGallon(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GallonToCubicMeters)), nameof(value)));
+	public static Capacity<T> FromGallons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GallonToCubicMeters)), nameof(value)));
 /// <summary>Implicit conversion to Volume.</summary>
 	public static implicit operator Volume<T>(Capacity<T> value) => Volume<T>.Create(value.Value);
 /// <summary>Explicit conversion from Volume.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CatalyticActivity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CatalyticActivity.g.cs
@@ -23,7 +23,7 @@ public record CatalyticActivity<T> : PhysicalQuantity<CatalyticActivity<T>, T>, 
 	/// <param name="value">The value in Katal.</param>
 	/// <returns>A new <see cref="CatalyticActivity{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static CatalyticActivity<T> FromKatal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static CatalyticActivity<T> FromKatals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two CatalyticActivity values, returning the absolute difference as a non-negative CatalyticActivity.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Charge.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Charge.g.cs
@@ -22,7 +22,7 @@ public record Charge<T> : PhysicalQuantity<Charge<T>, T>, IVector1<Charge<T>, T>
 	/// </summary>
 	/// <param name="value">The value in Coulomb.</param>
 	/// <returns>A new <see cref="Charge{T}"/> instance.</returns>
-	public static Charge<T> FromCoulomb(T value) => Create(value);
+	public static Charge<T> FromCoulombs(T value) => Create(value);
 /// <summary>
 	/// Gets the magnitude of this quantity as a <see cref="ChargeMagnitude{T}"/>.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ChargeMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ChargeMagnitude.g.cs
@@ -23,7 +23,7 @@ public record ChargeMagnitude<T> : PhysicalQuantity<ChargeMagnitude<T>, T>, IVec
 	/// <param name="value">The value in Coulomb.</param>
 	/// <returns>A new <see cref="ChargeMagnitude{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ChargeMagnitude<T> FromCoulomb(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static ChargeMagnitude<T> FromCoulombs(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two ChargeMagnitude values, returning the absolute difference as a non-negative ChargeMagnitude.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Concentration.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Concentration.g.cs
@@ -23,7 +23,7 @@ public record Concentration<T> : PhysicalQuantity<Concentration<T>, T>, IVector0
 	/// <param name="value">The value in Molar.</param>
 	/// <returns>A new <see cref="Concentration{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Concentration<T> FromMolar(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Concentration<T> FromMolars(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two Concentration values, returning the absolute difference as a non-negative Concentration.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CrossSectionalArea.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CrossSectionalArea.g.cs
@@ -24,21 +24,21 @@ public record CrossSectionalArea<T> : PhysicalQuantity<CrossSectionalArea<T>, T>
 	/// <param name="value">The value in SquareMeter.</param>
 	/// <returns>A new CrossSectionalArea instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static CrossSectionalArea<T> FromSquareMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static CrossSectionalArea<T> FromSquareMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new CrossSectionalArea from a value in SquareFoot.
 	/// </summary>
 	/// <param name="value">The value in SquareFoot.</param>
 	/// <returns>A new CrossSectionalArea instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static CrossSectionalArea<T> FromSquareFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareFootToSquareMeters)), nameof(value)));
+	public static CrossSectionalArea<T> FromSquareFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareFootToSquareMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new CrossSectionalArea from a value in SquareInch.
 	/// </summary>
 	/// <param name="value">The value in SquareInch.</param>
 	/// <returns>A new CrossSectionalArea instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static CrossSectionalArea<T> FromSquareInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareInchToSquareMeters)), nameof(value)));
+	public static CrossSectionalArea<T> FromSquareInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareInchToSquareMeters)), nameof(value)));
 /// <summary>Implicit conversion to Area.</summary>
 	public static implicit operator Area<T>(CrossSectionalArea<T> value) => Area<T>.Create(value.Value);
 /// <summary>Explicit conversion from Area.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Current1D.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Current1D.g.cs
@@ -22,7 +22,7 @@ public record Current1D<T> : PhysicalQuantity<Current1D<T>, T>, IVector1<Current
 	/// </summary>
 	/// <param name="value">The value in Ampere.</param>
 	/// <returns>A new <see cref="Current1D{T}"/> instance.</returns>
-	public static Current1D<T> FromAmpere(T value) => Create(value);
+	public static Current1D<T> FromAmperes(T value) => Create(value);
 /// <summary>
 	/// Gets the magnitude of this quantity as a <see cref="CurrentMagnitude{T}"/>.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CurrentMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CurrentMagnitude.g.cs
@@ -23,7 +23,7 @@ public record CurrentMagnitude<T> : PhysicalQuantity<CurrentMagnitude<T>, T>, IV
 	/// <param name="value">The value in Ampere.</param>
 	/// <returns>A new <see cref="CurrentMagnitude{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static CurrentMagnitude<T> FromAmpere(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static CurrentMagnitude<T> FromAmperes(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two CurrentMagnitude values, returning the absolute difference as a non-negative CurrentMagnitude.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/DecayTime.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/DecayTime.g.cs
@@ -24,49 +24,49 @@ public record DecayTime<T> : PhysicalQuantity<DecayTime<T>, T>, IVector0<DecayTi
 	/// <param name="value">The value in Second.</param>
 	/// <returns>A new DecayTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static DecayTime<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static DecayTime<T> FromSeconds(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new DecayTime from a value in Millisecond.
 	/// </summary>
 	/// <param name="value">The value in Millisecond.</param>
 	/// <returns>A new DecayTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static DecayTime<T> FromMillisecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static DecayTime<T> FromMilliseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new DecayTime from a value in Microsecond.
 	/// </summary>
 	/// <param name="value">The value in Microsecond.</param>
 	/// <returns>A new DecayTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static DecayTime<T> FromMicrosecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static DecayTime<T> FromMicroseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new DecayTime from a value in Minute.
 	/// </summary>
 	/// <param name="value">The value in Minute.</param>
 	/// <returns>A new DecayTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static DecayTime<T> FromMinute(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
+	public static DecayTime<T> FromMinutes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new DecayTime from a value in Hour.
 	/// </summary>
 	/// <param name="value">The value in Hour.</param>
 	/// <returns>A new DecayTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static DecayTime<T> FromHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
+	public static DecayTime<T> FromHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new DecayTime from a value in Day.
 	/// </summary>
 	/// <param name="value">The value in Day.</param>
 	/// <returns>A new DecayTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static DecayTime<T> FromDay(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
+	public static DecayTime<T> FromDays(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new DecayTime from a value in Year.
 	/// </summary>
 	/// <param name="value">The value in Year.</param>
 	/// <returns>A new DecayTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static DecayTime<T> FromYear(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
+	public static DecayTime<T> FromYears(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>Implicit conversion to Duration.</summary>
 	public static implicit operator Duration<T>(DecayTime<T> value) => Duration<T>.Create(value.Value);
 /// <summary>Explicit conversion from Duration.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Depth.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Depth.g.cs
@@ -24,77 +24,77 @@ public record Depth<T> : PhysicalQuantity<Depth<T>, T>, IVector0<Depth<T>, T>
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new Depth instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Depth<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Depth<T> FromMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Depth from a value in Kilometer.
 	/// </summary>
 	/// <param name="value">The value in Kilometer.</param>
 	/// <returns>A new Depth instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Depth<T> FromKilometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+	public static Depth<T> FromKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
 /// <summary>
 	/// Creates a new Depth from a value in Centimeter.
 	/// </summary>
 	/// <param name="value">The value in Centimeter.</param>
 	/// <returns>A new Depth instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Depth<T> FromCentimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
+	public static Depth<T> FromCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
 /// <summary>
 	/// Creates a new Depth from a value in Millimeter.
 	/// </summary>
 	/// <param name="value">The value in Millimeter.</param>
 	/// <returns>A new Depth instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Depth<T> FromMillimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Depth<T> FromMillimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new Depth from a value in Micrometer.
 	/// </summary>
 	/// <param name="value">The value in Micrometer.</param>
 	/// <returns>A new Depth instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Depth<T> FromMicrometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Depth<T> FromMicrometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new Depth from a value in Nanometer.
 	/// </summary>
 	/// <param name="value">The value in Nanometer.</param>
 	/// <returns>A new Depth instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Depth<T> FromNanometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+	public static Depth<T> FromNanometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
 /// <summary>
 	/// Creates a new Depth from a value in Angstrom.
 	/// </summary>
 	/// <param name="value">The value in Angstrom.</param>
 	/// <returns>A new Depth instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Depth<T> FromAngstrom(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
+	public static Depth<T> FromAngstroms(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Depth from a value in Foot.
 	/// </summary>
 	/// <param name="value">The value in Foot.</param>
 	/// <returns>A new Depth instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Depth<T> FromFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
+	public static Depth<T> FromFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Depth from a value in Inch.
 	/// </summary>
 	/// <param name="value">The value in Inch.</param>
 	/// <returns>A new Depth instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Depth<T> FromInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
+	public static Depth<T> FromInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Depth from a value in Yard.
 	/// </summary>
 	/// <param name="value">The value in Yard.</param>
 	/// <returns>A new Depth instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Depth<T> FromYard(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
+	public static Depth<T> FromYards(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Depth from a value in Mile.
 	/// </summary>
 	/// <param name="value">The value in Mile.</param>
 	/// <returns>A new Depth instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Depth<T> FromMile(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
+	public static Depth<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Depth<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Diameter.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Diameter.g.cs
@@ -24,77 +24,77 @@ public record Diameter<T> : PhysicalQuantity<Diameter<T>, T>, IVector0<Diameter<
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new Diameter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Diameter<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Diameter<T> FromMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Diameter from a value in Kilometer.
 	/// </summary>
 	/// <param name="value">The value in Kilometer.</param>
 	/// <returns>A new Diameter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Diameter<T> FromKilometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+	public static Diameter<T> FromKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
 /// <summary>
 	/// Creates a new Diameter from a value in Centimeter.
 	/// </summary>
 	/// <param name="value">The value in Centimeter.</param>
 	/// <returns>A new Diameter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Diameter<T> FromCentimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
+	public static Diameter<T> FromCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
 /// <summary>
 	/// Creates a new Diameter from a value in Millimeter.
 	/// </summary>
 	/// <param name="value">The value in Millimeter.</param>
 	/// <returns>A new Diameter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Diameter<T> FromMillimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Diameter<T> FromMillimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new Diameter from a value in Micrometer.
 	/// </summary>
 	/// <param name="value">The value in Micrometer.</param>
 	/// <returns>A new Diameter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Diameter<T> FromMicrometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Diameter<T> FromMicrometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new Diameter from a value in Nanometer.
 	/// </summary>
 	/// <param name="value">The value in Nanometer.</param>
 	/// <returns>A new Diameter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Diameter<T> FromNanometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+	public static Diameter<T> FromNanometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
 /// <summary>
 	/// Creates a new Diameter from a value in Angstrom.
 	/// </summary>
 	/// <param name="value">The value in Angstrom.</param>
 	/// <returns>A new Diameter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Diameter<T> FromAngstrom(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
+	public static Diameter<T> FromAngstroms(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Diameter from a value in Foot.
 	/// </summary>
 	/// <param name="value">The value in Foot.</param>
 	/// <returns>A new Diameter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Diameter<T> FromFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
+	public static Diameter<T> FromFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Diameter from a value in Inch.
 	/// </summary>
 	/// <param name="value">The value in Inch.</param>
 	/// <returns>A new Diameter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Diameter<T> FromInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
+	public static Diameter<T> FromInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Diameter from a value in Yard.
 	/// </summary>
 	/// <param name="value">The value in Yard.</param>
 	/// <returns>A new Diameter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Diameter<T> FromYard(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
+	public static Diameter<T> FromYards(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Diameter from a value in Mile.
 	/// </summary>
 	/// <param name="value">The value in Mile.</param>
 	/// <returns>A new Diameter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Diameter<T> FromMile(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
+	public static Diameter<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Diameter<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Displacement1D.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Displacement1D.g.cs
@@ -22,67 +22,67 @@ public record Displacement1D<T> : PhysicalQuantity<Displacement1D<T>, T>, IVecto
 	/// </summary>
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new <see cref="Displacement1D{T}"/> instance.</returns>
-	public static Displacement1D<T> FromMeter(T value) => Create(value);
+	public static Displacement1D<T> FromMeters(T value) => Create(value);
 /// <summary>
 	/// Creates a new <see cref="Displacement1D{T}"/> from a value in Kilometer.
 	/// </summary>
 	/// <param name="value">The value in Kilometer.</param>
 	/// <returns>A new <see cref="Displacement1D{T}"/> instance.</returns>
-	public static Displacement1D<T> FromKilometer(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Kilo)));
+	public static Displacement1D<T> FromKilometers(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Kilo)));
 /// <summary>
 	/// Creates a new <see cref="Displacement1D{T}"/> from a value in Centimeter.
 	/// </summary>
 	/// <param name="value">The value in Centimeter.</param>
 	/// <returns>A new <see cref="Displacement1D{T}"/> instance.</returns>
-	public static Displacement1D<T> FromCentimeter(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Centi)));
+	public static Displacement1D<T> FromCentimeters(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Centi)));
 /// <summary>
 	/// Creates a new <see cref="Displacement1D{T}"/> from a value in Millimeter.
 	/// </summary>
 	/// <param name="value">The value in Millimeter.</param>
 	/// <returns>A new <see cref="Displacement1D{T}"/> instance.</returns>
-	public static Displacement1D<T> FromMillimeter(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Milli)));
+	public static Displacement1D<T> FromMillimeters(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Milli)));
 /// <summary>
 	/// Creates a new <see cref="Displacement1D{T}"/> from a value in Micrometer.
 	/// </summary>
 	/// <param name="value">The value in Micrometer.</param>
 	/// <returns>A new <see cref="Displacement1D{T}"/> instance.</returns>
-	public static Displacement1D<T> FromMicrometer(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Micro)));
+	public static Displacement1D<T> FromMicrometers(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Micro)));
 /// <summary>
 	/// Creates a new <see cref="Displacement1D{T}"/> from a value in Nanometer.
 	/// </summary>
 	/// <param name="value">The value in Nanometer.</param>
 	/// <returns>A new <see cref="Displacement1D{T}"/> instance.</returns>
-	public static Displacement1D<T> FromNanometer(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Nano)));
+	public static Displacement1D<T> FromNanometers(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Nano)));
 /// <summary>
 	/// Creates a new <see cref="Displacement1D{T}"/> from a value in Angstrom.
 	/// </summary>
 	/// <param name="value">The value in Angstrom.</param>
 	/// <returns>A new <see cref="Displacement1D{T}"/> instance.</returns>
-	public static Displacement1D<T> FromAngstrom(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)));
+	public static Displacement1D<T> FromAngstroms(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)));
 /// <summary>
 	/// Creates a new <see cref="Displacement1D{T}"/> from a value in Foot.
 	/// </summary>
 	/// <param name="value">The value in Foot.</param>
 	/// <returns>A new <see cref="Displacement1D{T}"/> instance.</returns>
-	public static Displacement1D<T> FromFoot(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)));
+	public static Displacement1D<T> FromFeet(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)));
 /// <summary>
 	/// Creates a new <see cref="Displacement1D{T}"/> from a value in Inch.
 	/// </summary>
 	/// <param name="value">The value in Inch.</param>
 	/// <returns>A new <see cref="Displacement1D{T}"/> instance.</returns>
-	public static Displacement1D<T> FromInch(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)));
+	public static Displacement1D<T> FromInches(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)));
 /// <summary>
 	/// Creates a new <see cref="Displacement1D{T}"/> from a value in Yard.
 	/// </summary>
 	/// <param name="value">The value in Yard.</param>
 	/// <returns>A new <see cref="Displacement1D{T}"/> instance.</returns>
-	public static Displacement1D<T> FromYard(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)));
+	public static Displacement1D<T> FromYards(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)));
 /// <summary>
 	/// Creates a new <see cref="Displacement1D{T}"/> from a value in Mile.
 	/// </summary>
 	/// <param name="value">The value in Mile.</param>
 	/// <returns>A new <see cref="Displacement1D{T}"/> instance.</returns>
-	public static Displacement1D<T> FromMile(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)));
+	public static Displacement1D<T> FromMiles(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)));
 /// <summary>
 	/// Gets the magnitude of this quantity as a <see cref="Length{T}"/>.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Distance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Distance.g.cs
@@ -24,77 +24,77 @@ public record Distance<T> : PhysicalQuantity<Distance<T>, T>, IVector0<Distance<
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new Distance instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Distance<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Distance<T> FromMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Distance from a value in Kilometer.
 	/// </summary>
 	/// <param name="value">The value in Kilometer.</param>
 	/// <returns>A new Distance instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Distance<T> FromKilometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+	public static Distance<T> FromKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
 /// <summary>
 	/// Creates a new Distance from a value in Centimeter.
 	/// </summary>
 	/// <param name="value">The value in Centimeter.</param>
 	/// <returns>A new Distance instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Distance<T> FromCentimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
+	public static Distance<T> FromCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
 /// <summary>
 	/// Creates a new Distance from a value in Millimeter.
 	/// </summary>
 	/// <param name="value">The value in Millimeter.</param>
 	/// <returns>A new Distance instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Distance<T> FromMillimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Distance<T> FromMillimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new Distance from a value in Micrometer.
 	/// </summary>
 	/// <param name="value">The value in Micrometer.</param>
 	/// <returns>A new Distance instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Distance<T> FromMicrometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Distance<T> FromMicrometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new Distance from a value in Nanometer.
 	/// </summary>
 	/// <param name="value">The value in Nanometer.</param>
 	/// <returns>A new Distance instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Distance<T> FromNanometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+	public static Distance<T> FromNanometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
 /// <summary>
 	/// Creates a new Distance from a value in Angstrom.
 	/// </summary>
 	/// <param name="value">The value in Angstrom.</param>
 	/// <returns>A new Distance instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Distance<T> FromAngstrom(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
+	public static Distance<T> FromAngstroms(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Distance from a value in Foot.
 	/// </summary>
 	/// <param name="value">The value in Foot.</param>
 	/// <returns>A new Distance instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Distance<T> FromFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
+	public static Distance<T> FromFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Distance from a value in Inch.
 	/// </summary>
 	/// <param name="value">The value in Inch.</param>
 	/// <returns>A new Distance instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Distance<T> FromInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
+	public static Distance<T> FromInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Distance from a value in Yard.
 	/// </summary>
 	/// <param name="value">The value in Yard.</param>
 	/// <returns>A new Distance instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Distance<T> FromYard(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
+	public static Distance<T> FromYards(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Distance from a value in Mile.
 	/// </summary>
 	/// <param name="value">The value in Mile.</param>
 	/// <returns>A new Distance instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Distance<T> FromMile(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
+	public static Distance<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Distance<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Drag.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Drag.g.cs
@@ -24,7 +24,7 @@ public record Drag<T> : PhysicalQuantity<Drag<T>, T>, IVector0<Drag<T>, T>
 	/// <param name="value">The value in Newton.</param>
 	/// <returns>A new Drag instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Drag<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Drag<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(Drag<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Duration.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Duration.g.cs
@@ -23,49 +23,49 @@ public record Duration<T> : PhysicalQuantity<Duration<T>, T>, IVector0<Duration<
 	/// <param name="value">The value in Second.</param>
 	/// <returns>A new <see cref="Duration{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Duration<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Duration<T> FromSeconds(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Duration{T}"/> from a value in Millisecond.
 	/// </summary>
 	/// <param name="value">The value in Millisecond.</param>
 	/// <returns>A new <see cref="Duration{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Duration<T> FromMillisecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Duration<T> FromMilliseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Duration{T}"/> from a value in Microsecond.
 	/// </summary>
 	/// <param name="value">The value in Microsecond.</param>
 	/// <returns>A new <see cref="Duration{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Duration<T> FromMicrosecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Duration<T> FromMicroseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Duration{T}"/> from a value in Minute.
 	/// </summary>
 	/// <param name="value">The value in Minute.</param>
 	/// <returns>A new <see cref="Duration{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Duration<T> FromMinute(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
+	public static Duration<T> FromMinutes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Duration{T}"/> from a value in Hour.
 	/// </summary>
 	/// <param name="value">The value in Hour.</param>
 	/// <returns>A new <see cref="Duration{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Duration<T> FromHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
+	public static Duration<T> FromHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Duration{T}"/> from a value in Day.
 	/// </summary>
 	/// <param name="value">The value in Day.</param>
 	/// <returns>A new <see cref="Duration{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Duration<T> FromDay(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
+	public static Duration<T> FromDays(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Duration{T}"/> from a value in Year.
 	/// </summary>
 	/// <param name="value">The value in Year.</param>
 	/// <returns>A new <see cref="Duration{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Duration<T> FromYear(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
+	public static Duration<T> FromYears(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>
 	/// Subtracts two Duration values, returning the absolute difference as a non-negative Duration.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/DynamicViscosity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/DynamicViscosity.g.cs
@@ -23,7 +23,7 @@ public record DynamicViscosity<T> : PhysicalQuantity<DynamicViscosity<T>, T>, IV
 	/// <param name="value">The value in PascalSecond.</param>
 	/// <returns>A new <see cref="DynamicViscosity{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static DynamicViscosity<T> FromPascalSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static DynamicViscosity<T> FromPascalSeconds(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="DynamicViscosity{T}"/> from a value in Poise.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EMF.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EMF.g.cs
@@ -24,7 +24,7 @@ public record EMF<T> : PhysicalQuantity<EMF<T>, T>, IVector0<EMF<T>, T>
 	/// <param name="value">The value in Volt.</param>
 	/// <returns>A new EMF instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static EMF<T> FromVolt(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static EMF<T> FromVolts(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to VoltageMagnitude.</summary>
 	public static implicit operator VoltageMagnitude<T>(EMF<T> value) => VoltageMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from VoltageMagnitude.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Energy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Energy.g.cs
@@ -23,28 +23,28 @@ public record Energy<T> : PhysicalQuantity<Energy<T>, T>, IVector0<Energy<T>, T>
 	/// <param name="value">The value in Joule.</param>
 	/// <returns>A new <see cref="Energy{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Energy<T> FromJoule(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Energy<T> FromJoules(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Energy{T}"/> from a value in ElectronVolt.
 	/// </summary>
 	/// <param name="value">The value in ElectronVolt.</param>
 	/// <returns>A new <see cref="Energy{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Energy<T> FromElectronVolt(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ElectronVoltToJoules)), nameof(value)));
+	public static Energy<T> FromElectronVolts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ElectronVoltToJoules)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Energy{T}"/> from a value in Calorie.
 	/// </summary>
 	/// <param name="value">The value in Calorie.</param>
 	/// <returns>A new <see cref="Energy{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Energy<T> FromCalorie(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
+	public static Energy<T> FromCalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Energy{T}"/> from a value in KilowattHour.
 	/// </summary>
 	/// <param name="value">The value in KilowattHour.</param>
 	/// <returns>A new <see cref="Energy{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Energy<T> FromKilowattHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
+	public static Energy<T> FromKilowattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
 /// <summary>
 	/// Subtracts two Energy values, returning the absolute difference as a non-negative Energy.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EnzymeActivity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EnzymeActivity.g.cs
@@ -24,7 +24,7 @@ public record EnzymeActivity<T> : PhysicalQuantity<EnzymeActivity<T>, T>, IVecto
 	/// <param name="value">The value in Katal.</param>
 	/// <returns>A new EnzymeActivity instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static EnzymeActivity<T> FromKatal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static EnzymeActivity<T> FromKatals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to CatalyticActivity.</summary>
 	public static implicit operator CatalyticActivity<T>(EnzymeActivity<T> value) => CatalyticActivity<T>.Create(value.Value);
 /// <summary>Explicit conversion from CatalyticActivity.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EquivalentDose.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EquivalentDose.g.cs
@@ -23,7 +23,7 @@ public record EquivalentDose<T> : PhysicalQuantity<EquivalentDose<T>, T>, IVecto
 	/// <param name="value">The value in Sievert.</param>
 	/// <returns>A new <see cref="EquivalentDose{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static EquivalentDose<T> FromSievert(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static EquivalentDose<T> FromSieverts(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two EquivalentDose values, returning the absolute difference as a non-negative EquivalentDose.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/FieldOfView.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/FieldOfView.g.cs
@@ -24,14 +24,14 @@ public record FieldOfView<T> : PhysicalQuantity<FieldOfView<T>, T>, IVector0<Fie
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new FieldOfView instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static FieldOfView<T> FromRadian(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static FieldOfView<T> FromRadians(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new FieldOfView from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new FieldOfView instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static FieldOfView<T> FromDegree(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
+	public static FieldOfView<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>Implicit conversion to Angle.</summary>
 	public static implicit operator Angle<T>(FieldOfView<T> value) => Angle<T>.Create(value.Value);
 /// <summary>Explicit conversion from Angle.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Force1D.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Force1D.g.cs
@@ -22,7 +22,7 @@ public record Force1D<T> : PhysicalQuantity<Force1D<T>, T>, IVector1<Force1D<T>,
 	/// </summary>
 	/// <param name="value">The value in Newton.</param>
 	/// <returns>A new <see cref="Force1D{T}"/> instance.</returns>
-	public static Force1D<T> FromNewton(T value) => Create(value);
+	public static Force1D<T> FromNewtons(T value) => Create(value);
 /// <summary>
 	/// Gets the magnitude of this quantity as a <see cref="ForceMagnitude{T}"/>.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ForceMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ForceMagnitude.g.cs
@@ -23,7 +23,7 @@ public record ForceMagnitude<T> : PhysicalQuantity<ForceMagnitude<T>, T>, IVecto
 	/// <param name="value">The value in Newton.</param>
 	/// <returns>A new <see cref="ForceMagnitude{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ForceMagnitude<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static ForceMagnitude<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two ForceMagnitude values, returning the absolute difference as a non-negative ForceMagnitude.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Friction.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Friction.g.cs
@@ -24,7 +24,7 @@ public record Friction<T> : PhysicalQuantity<Friction<T>, T>, IVector0<Friction<
 	/// <param name="value">The value in Newton.</param>
 	/// <returns>A new Friction instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Friction<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Friction<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(Friction<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GaugePressure.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GaugePressure.g.cs
@@ -24,21 +24,21 @@ public record GaugePressure<T> : PhysicalQuantity<GaugePressure<T>, T>, IVector0
 	/// <param name="value">The value in Pascal.</param>
 	/// <returns>A new GaugePressure instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static GaugePressure<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static GaugePressure<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new GaugePressure from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
 	/// <returns>A new GaugePressure instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static GaugePressure<T> FromBar(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
+	public static GaugePressure<T> FromBars(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new GaugePressure from a value in Atmosphere.
 	/// </summary>
 	/// <param name="value">The value in Atmosphere.</param>
 	/// <returns>A new GaugePressure instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static GaugePressure<T> FromAtmosphere(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
+	public static GaugePressure<T> FromAtmospheres(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new GaugePressure from a value in Psi.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HalfLife.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HalfLife.g.cs
@@ -24,49 +24,49 @@ public record HalfLife<T> : PhysicalQuantity<HalfLife<T>, T>, IVector0<HalfLife<
 	/// <param name="value">The value in Second.</param>
 	/// <returns>A new HalfLife instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static HalfLife<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static HalfLife<T> FromSeconds(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new HalfLife from a value in Millisecond.
 	/// </summary>
 	/// <param name="value">The value in Millisecond.</param>
 	/// <returns>A new HalfLife instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static HalfLife<T> FromMillisecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static HalfLife<T> FromMilliseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new HalfLife from a value in Microsecond.
 	/// </summary>
 	/// <param name="value">The value in Microsecond.</param>
 	/// <returns>A new HalfLife instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static HalfLife<T> FromMicrosecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static HalfLife<T> FromMicroseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new HalfLife from a value in Minute.
 	/// </summary>
 	/// <param name="value">The value in Minute.</param>
 	/// <returns>A new HalfLife instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static HalfLife<T> FromMinute(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
+	public static HalfLife<T> FromMinutes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new HalfLife from a value in Hour.
 	/// </summary>
 	/// <param name="value">The value in Hour.</param>
 	/// <returns>A new HalfLife instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static HalfLife<T> FromHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
+	public static HalfLife<T> FromHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new HalfLife from a value in Day.
 	/// </summary>
 	/// <param name="value">The value in Day.</param>
 	/// <returns>A new HalfLife instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static HalfLife<T> FromDay(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
+	public static HalfLife<T> FromDays(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new HalfLife from a value in Year.
 	/// </summary>
 	/// <param name="value">The value in Year.</param>
 	/// <returns>A new HalfLife instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static HalfLife<T> FromYear(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
+	public static HalfLife<T> FromYears(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>Implicit conversion to Duration.</summary>
 	public static implicit operator Duration<T>(HalfLife<T> value) => Duration<T>.Create(value.Value);
 /// <summary>Explicit conversion from Duration.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Heading.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Heading.g.cs
@@ -23,13 +23,13 @@ public record Heading<T> : PhysicalQuantity<Heading<T>, T>, IVector1<Heading<T>,
 	/// </summary>
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new Heading instance.</returns>
-	public static Heading<T> FromRadian(T value) => Create(value);
+	public static Heading<T> FromRadians(T value) => Create(value);
 /// <summary>
 	/// Creates a new Heading from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new Heading instance.</returns>
-	public static Heading<T> FromDegree(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
+	public static Heading<T> FromDegrees(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
 /// <summary>Implicit conversion to SignedAngle.</summary>
 	public static implicit operator SignedAngle<T>(Heading<T> value) => SignedAngle<T>.Create(value.Value);
 /// <summary>Explicit conversion from SignedAngle.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Heat.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Heat.g.cs
@@ -24,28 +24,28 @@ public record Heat<T> : PhysicalQuantity<Heat<T>, T>, IVector0<Heat<T>, T>
 	/// <param name="value">The value in Joule.</param>
 	/// <returns>A new Heat instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Heat<T> FromJoule(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Heat<T> FromJoules(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Heat from a value in ElectronVolt.
 	/// </summary>
 	/// <param name="value">The value in ElectronVolt.</param>
 	/// <returns>A new Heat instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Heat<T> FromElectronVolt(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ElectronVoltToJoules)), nameof(value)));
+	public static Heat<T> FromElectronVolts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ElectronVoltToJoules)), nameof(value)));
 /// <summary>
 	/// Creates a new Heat from a value in Calorie.
 	/// </summary>
 	/// <param name="value">The value in Calorie.</param>
 	/// <returns>A new Heat instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Heat<T> FromCalorie(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
+	public static Heat<T> FromCalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
 /// <summary>
 	/// Creates a new Heat from a value in KilowattHour.
 	/// </summary>
 	/// <param name="value">The value in KilowattHour.</param>
 	/// <returns>A new Heat instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Heat<T> FromKilowattHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
+	public static Heat<T> FromKilowattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
 /// <summary>Implicit conversion to Energy.</summary>
 	public static implicit operator Energy<T>(Heat<T> value) => Energy<T>.Create(value.Value);
 /// <summary>Explicit conversion from Energy.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HeatFlowRate.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HeatFlowRate.g.cs
@@ -24,7 +24,7 @@ public record HeatFlowRate<T> : PhysicalQuantity<HeatFlowRate<T>, T>, IVector0<H
 	/// <param name="value">The value in Watt.</param>
 	/// <returns>A new HeatFlowRate instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static HeatFlowRate<T> FromWatt(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static HeatFlowRate<T> FromWatts(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new HeatFlowRate from a value in Horsepower.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Height.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Height.g.cs
@@ -24,77 +24,77 @@ public record Height<T> : PhysicalQuantity<Height<T>, T>, IVector0<Height<T>, T>
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new Height instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Height<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Height<T> FromMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Height from a value in Kilometer.
 	/// </summary>
 	/// <param name="value">The value in Kilometer.</param>
 	/// <returns>A new Height instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Height<T> FromKilometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+	public static Height<T> FromKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
 /// <summary>
 	/// Creates a new Height from a value in Centimeter.
 	/// </summary>
 	/// <param name="value">The value in Centimeter.</param>
 	/// <returns>A new Height instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Height<T> FromCentimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
+	public static Height<T> FromCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
 /// <summary>
 	/// Creates a new Height from a value in Millimeter.
 	/// </summary>
 	/// <param name="value">The value in Millimeter.</param>
 	/// <returns>A new Height instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Height<T> FromMillimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Height<T> FromMillimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new Height from a value in Micrometer.
 	/// </summary>
 	/// <param name="value">The value in Micrometer.</param>
 	/// <returns>A new Height instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Height<T> FromMicrometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Height<T> FromMicrometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new Height from a value in Nanometer.
 	/// </summary>
 	/// <param name="value">The value in Nanometer.</param>
 	/// <returns>A new Height instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Height<T> FromNanometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+	public static Height<T> FromNanometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
 /// <summary>
 	/// Creates a new Height from a value in Angstrom.
 	/// </summary>
 	/// <param name="value">The value in Angstrom.</param>
 	/// <returns>A new Height instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Height<T> FromAngstrom(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
+	public static Height<T> FromAngstroms(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Height from a value in Foot.
 	/// </summary>
 	/// <param name="value">The value in Foot.</param>
 	/// <returns>A new Height instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Height<T> FromFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
+	public static Height<T> FromFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Height from a value in Inch.
 	/// </summary>
 	/// <param name="value">The value in Inch.</param>
 	/// <returns>A new Height instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Height<T> FromInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
+	public static Height<T> FromInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Height from a value in Yard.
 	/// </summary>
 	/// <param name="value">The value in Yard.</param>
 	/// <returns>A new Height instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Height<T> FromYard(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
+	public static Height<T> FromYards(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Height from a value in Mile.
 	/// </summary>
 	/// <param name="value">The value in Mile.</param>
 	/// <returns>A new Height instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Height<T> FromMile(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
+	public static Height<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Height<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Inductance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Inductance.g.cs
@@ -23,7 +23,7 @@ public record Inductance<T> : PhysicalQuantity<Inductance<T>, T>, IVector0<Induc
 	/// <param name="value">The value in Henry.</param>
 	/// <returns>A new <see cref="Inductance{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Inductance<T> FromHenry(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Inductance<T> FromHenries(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two Inductance values, returning the absolute difference as a non-negative Inductance.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/KineticEnergy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/KineticEnergy.g.cs
@@ -24,28 +24,28 @@ public record KineticEnergy<T> : PhysicalQuantity<KineticEnergy<T>, T>, IVector0
 	/// <param name="value">The value in Joule.</param>
 	/// <returns>A new KineticEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static KineticEnergy<T> FromJoule(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static KineticEnergy<T> FromJoules(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new KineticEnergy from a value in ElectronVolt.
 	/// </summary>
 	/// <param name="value">The value in ElectronVolt.</param>
 	/// <returns>A new KineticEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static KineticEnergy<T> FromElectronVolt(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ElectronVoltToJoules)), nameof(value)));
+	public static KineticEnergy<T> FromElectronVolts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ElectronVoltToJoules)), nameof(value)));
 /// <summary>
 	/// Creates a new KineticEnergy from a value in Calorie.
 	/// </summary>
 	/// <param name="value">The value in Calorie.</param>
 	/// <returns>A new KineticEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static KineticEnergy<T> FromCalorie(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
+	public static KineticEnergy<T> FromCalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
 /// <summary>
 	/// Creates a new KineticEnergy from a value in KilowattHour.
 	/// </summary>
 	/// <param name="value">The value in KilowattHour.</param>
 	/// <returns>A new KineticEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static KineticEnergy<T> FromKilowattHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
+	public static KineticEnergy<T> FromKilowattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
 /// <summary>Implicit conversion to Energy.</summary>
 	public static implicit operator Energy<T>(KineticEnergy<T> value) => Energy<T>.Create(value.Value);
 /// <summary>Explicit conversion from Energy.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Latency.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Latency.g.cs
@@ -24,49 +24,49 @@ public record Latency<T> : PhysicalQuantity<Latency<T>, T>, IVector0<Latency<T>,
 	/// <param name="value">The value in Second.</param>
 	/// <returns>A new Latency instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Latency<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Latency<T> FromSeconds(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Latency from a value in Millisecond.
 	/// </summary>
 	/// <param name="value">The value in Millisecond.</param>
 	/// <returns>A new Latency instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Latency<T> FromMillisecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Latency<T> FromMilliseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new Latency from a value in Microsecond.
 	/// </summary>
 	/// <param name="value">The value in Microsecond.</param>
 	/// <returns>A new Latency instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Latency<T> FromMicrosecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Latency<T> FromMicroseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new Latency from a value in Minute.
 	/// </summary>
 	/// <param name="value">The value in Minute.</param>
 	/// <returns>A new Latency instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Latency<T> FromMinute(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
+	public static Latency<T> FromMinutes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new Latency from a value in Hour.
 	/// </summary>
 	/// <param name="value">The value in Hour.</param>
 	/// <returns>A new Latency instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Latency<T> FromHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
+	public static Latency<T> FromHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new Latency from a value in Day.
 	/// </summary>
 	/// <param name="value">The value in Day.</param>
 	/// <returns>A new Latency instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Latency<T> FromDay(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
+	public static Latency<T> FromDays(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new Latency from a value in Year.
 	/// </summary>
 	/// <param name="value">The value in Year.</param>
 	/// <returns>A new Latency instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Latency<T> FromYear(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
+	public static Latency<T> FromYears(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>Implicit conversion to Duration.</summary>
 	public static implicit operator Duration<T>(Latency<T> value) => Duration<T>.Create(value.Value);
 /// <summary>Explicit conversion from Duration.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Length.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Length.g.cs
@@ -23,77 +23,77 @@ public record Length<T> : PhysicalQuantity<Length<T>, T>, IVector0<Length<T>, T>
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new <see cref="Length{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Length<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Length<T> FromMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Length{T}"/> from a value in Kilometer.
 	/// </summary>
 	/// <param name="value">The value in Kilometer.</param>
 	/// <returns>A new <see cref="Length{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Length<T> FromKilometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+	public static Length<T> FromKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Length{T}"/> from a value in Centimeter.
 	/// </summary>
 	/// <param name="value">The value in Centimeter.</param>
 	/// <returns>A new <see cref="Length{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Length<T> FromCentimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
+	public static Length<T> FromCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Length{T}"/> from a value in Millimeter.
 	/// </summary>
 	/// <param name="value">The value in Millimeter.</param>
 	/// <returns>A new <see cref="Length{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Length<T> FromMillimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Length<T> FromMillimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Length{T}"/> from a value in Micrometer.
 	/// </summary>
 	/// <param name="value">The value in Micrometer.</param>
 	/// <returns>A new <see cref="Length{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Length<T> FromMicrometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Length<T> FromMicrometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Length{T}"/> from a value in Nanometer.
 	/// </summary>
 	/// <param name="value">The value in Nanometer.</param>
 	/// <returns>A new <see cref="Length{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Length<T> FromNanometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+	public static Length<T> FromNanometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Length{T}"/> from a value in Angstrom.
 	/// </summary>
 	/// <param name="value">The value in Angstrom.</param>
 	/// <returns>A new <see cref="Length{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Length<T> FromAngstrom(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
+	public static Length<T> FromAngstroms(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Length{T}"/> from a value in Foot.
 	/// </summary>
 	/// <param name="value">The value in Foot.</param>
 	/// <returns>A new <see cref="Length{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Length<T> FromFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
+	public static Length<T> FromFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Length{T}"/> from a value in Inch.
 	/// </summary>
 	/// <param name="value">The value in Inch.</param>
 	/// <returns>A new <see cref="Length{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Length<T> FromInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
+	public static Length<T> FromInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Length{T}"/> from a value in Yard.
 	/// </summary>
 	/// <param name="value">The value in Yard.</param>
 	/// <returns>A new <see cref="Length{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Length<T> FromYard(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
+	public static Length<T> FromYards(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Length{T}"/> from a value in Mile.
 	/// </summary>
 	/// <param name="value">The value in Mile.</param>
 	/// <returns>A new <see cref="Length{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Length<T> FromMile(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
+	public static Length<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>
 	/// Subtracts two Length values, returning the absolute difference as a non-negative Length.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Lift.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Lift.g.cs
@@ -24,7 +24,7 @@ public record Lift<T> : PhysicalQuantity<Lift<T>, T>, IVector0<Lift<T>, T>
 	/// <param name="value">The value in Newton.</param>
 	/// <returns>A new Lift instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Lift<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Lift<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(Lift<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/LuminousFlux.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/LuminousFlux.g.cs
@@ -23,7 +23,7 @@ public record LuminousFlux<T> : PhysicalQuantity<LuminousFlux<T>, T>, IVector0<L
 	/// <param name="value">The value in Lumen.</param>
 	/// <returns>A new <see cref="LuminousFlux{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static LuminousFlux<T> FromLumen(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static LuminousFlux<T> FromLumens(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two LuminousFlux values, returning the absolute difference as a non-negative LuminousFlux.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/LuminousIntensity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/LuminousIntensity.g.cs
@@ -23,7 +23,7 @@ public record LuminousIntensity<T> : PhysicalQuantity<LuminousIntensity<T>, T>, 
 	/// <param name="value">The value in Candela.</param>
 	/// <returns>A new <see cref="LuminousIntensity{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static LuminousIntensity<T> FromCandela(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static LuminousIntensity<T> FromCandelas(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two LuminousIntensity values, returning the absolute difference as a non-negative LuminousIntensity.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MachNumber.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MachNumber.g.cs
@@ -31,14 +31,14 @@ public record MachNumber<T> : PhysicalQuantity<MachNumber<T>, T>, IVector0<MachN
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new MachNumber instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static MachNumber<T> FromRadian(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static MachNumber<T> FromRadians(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new MachNumber from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new MachNumber instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static MachNumber<T> FromDegree(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
+	public static MachNumber<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>Implicit conversion to Ratio.</summary>
 	public static implicit operator Ratio<T>(MachNumber<T> value) => Ratio<T>.Create(value.Value);
 /// <summary>Explicit conversion from Ratio.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MagneticFlux.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MagneticFlux.g.cs
@@ -23,7 +23,7 @@ public record MagneticFlux<T> : PhysicalQuantity<MagneticFlux<T>, T>, IVector0<M
 	/// <param name="value">The value in Weber.</param>
 	/// <returns>A new <see cref="MagneticFlux{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static MagneticFlux<T> FromWeber(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static MagneticFlux<T> FromWebers(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two MagneticFlux values, returning the absolute difference as a non-negative MagneticFlux.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MagneticFluxDensityMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MagneticFluxDensityMagnitude.g.cs
@@ -23,7 +23,7 @@ public record MagneticFluxDensityMagnitude<T> : PhysicalQuantity<MagneticFluxDen
 	/// <param name="value">The value in Tesla.</param>
 	/// <returns>A new <see cref="MagneticFluxDensityMagnitude{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static MagneticFluxDensityMagnitude<T> FromTesla(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static MagneticFluxDensityMagnitude<T> FromTeslas(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="MagneticFluxDensityMagnitude{T}"/> from a value in Gauss.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Mass.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Mass.g.cs
@@ -23,35 +23,35 @@ public record Mass<T> : PhysicalQuantity<Mass<T>, T>, IVector0<Mass<T>, T>
 	/// <param name="value">The value in Kilogram.</param>
 	/// <returns>A new <see cref="Mass{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Mass<T> FromKilogram(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Mass<T> FromKilograms(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Mass{T}"/> from a value in Gram.
 	/// </summary>
 	/// <param name="value">The value in Gram.</param>
 	/// <returns>A new <see cref="Mass{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Mass<T> FromGram(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Mass<T> FromGrams(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Mass{T}"/> from a value in Ton.
 	/// </summary>
 	/// <param name="value">The value in Ton.</param>
 	/// <returns>A new <see cref="Mass{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Mass<T> FromTon(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.TonToKilograms)), nameof(value)));
+	public static Mass<T> FromTons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.TonToKilograms)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Mass{T}"/> from a value in Pound.
 	/// </summary>
 	/// <param name="value">The value in Pound.</param>
 	/// <returns>A new <see cref="Mass{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Mass<T> FromPound(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundToKilograms)), nameof(value)));
+	public static Mass<T> FromPounds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundToKilograms)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Mass{T}"/> from a value in Ounce.
 	/// </summary>
 	/// <param name="value">The value in Ounce.</param>
 	/// <returns>A new <see cref="Mass{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Mass<T> FromOunce(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.OunceToKilograms)), nameof(value)));
+	public static Mass<T> FromOunces(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.OunceToKilograms)), nameof(value)));
 /// <summary>
 	/// Subtracts two Mass values, returning the absolute difference as a non-negative Mass.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Momentum1D.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Momentum1D.g.cs
@@ -22,7 +22,7 @@ public record Momentum1D<T> : PhysicalQuantity<Momentum1D<T>, T>, IVector1<Momen
 	/// </summary>
 	/// <param name="value">The value in NewtonSecond.</param>
 	/// <returns>A new <see cref="Momentum1D{T}"/> instance.</returns>
-	public static Momentum1D<T> FromNewtonSecond(T value) => Create(value);
+	public static Momentum1D<T> FromNewtonSeconds(T value) => Create(value);
 /// <summary>
 	/// Gets the magnitude of this quantity as a <see cref="MomentumMagnitude{T}"/>.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MomentumMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MomentumMagnitude.g.cs
@@ -23,7 +23,7 @@ public record MomentumMagnitude<T> : PhysicalQuantity<MomentumMagnitude<T>, T>, 
 	/// <param name="value">The value in NewtonSecond.</param>
 	/// <returns>A new <see cref="MomentumMagnitude{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static MomentumMagnitude<T> FromNewtonSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static MomentumMagnitude<T> FromNewtonSeconds(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two MomentumMagnitude values, returning the absolute difference as a non-negative MomentumMagnitude.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/NormalForce.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/NormalForce.g.cs
@@ -24,7 +24,7 @@ public record NormalForce<T> : PhysicalQuantity<NormalForce<T>, T>, IVector0<Nor
 	/// <param name="value">The value in Newton.</param>
 	/// <returns>A new NormalForce instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static NormalForce<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static NormalForce<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(NormalForce<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/NuclearCrossSection.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/NuclearCrossSection.g.cs
@@ -23,7 +23,7 @@ public record NuclearCrossSection<T> : PhysicalQuantity<NuclearCrossSection<T>, 
 	/// <param name="value">The value in Barn.</param>
 	/// <returns>A new <see cref="NuclearCrossSection{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static NuclearCrossSection<T> FromBarn(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static NuclearCrossSection<T> FromBarns(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two NuclearCrossSection values, returning the absolute difference as a non-negative NuclearCrossSection.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Offset.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Offset.g.cs
@@ -23,67 +23,67 @@ public record Offset<T> : PhysicalQuantity<Offset<T>, T>, IVector1<Offset<T>, T>
 	/// </summary>
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new Offset instance.</returns>
-	public static Offset<T> FromMeter(T value) => Create(value);
+	public static Offset<T> FromMeters(T value) => Create(value);
 /// <summary>
 	/// Creates a new Offset from a value in Kilometer.
 	/// </summary>
 	/// <param name="value">The value in Kilometer.</param>
 	/// <returns>A new Offset instance.</returns>
-	public static Offset<T> FromKilometer(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Kilo)));
+	public static Offset<T> FromKilometers(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Kilo)));
 /// <summary>
 	/// Creates a new Offset from a value in Centimeter.
 	/// </summary>
 	/// <param name="value">The value in Centimeter.</param>
 	/// <returns>A new Offset instance.</returns>
-	public static Offset<T> FromCentimeter(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Centi)));
+	public static Offset<T> FromCentimeters(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Centi)));
 /// <summary>
 	/// Creates a new Offset from a value in Millimeter.
 	/// </summary>
 	/// <param name="value">The value in Millimeter.</param>
 	/// <returns>A new Offset instance.</returns>
-	public static Offset<T> FromMillimeter(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Milli)));
+	public static Offset<T> FromMillimeters(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Milli)));
 /// <summary>
 	/// Creates a new Offset from a value in Micrometer.
 	/// </summary>
 	/// <param name="value">The value in Micrometer.</param>
 	/// <returns>A new Offset instance.</returns>
-	public static Offset<T> FromMicrometer(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Micro)));
+	public static Offset<T> FromMicrometers(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Micro)));
 /// <summary>
 	/// Creates a new Offset from a value in Nanometer.
 	/// </summary>
 	/// <param name="value">The value in Nanometer.</param>
 	/// <returns>A new Offset instance.</returns>
-	public static Offset<T> FromNanometer(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Nano)));
+	public static Offset<T> FromNanometers(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Nano)));
 /// <summary>
 	/// Creates a new Offset from a value in Angstrom.
 	/// </summary>
 	/// <param name="value">The value in Angstrom.</param>
 	/// <returns>A new Offset instance.</returns>
-	public static Offset<T> FromAngstrom(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)));
+	public static Offset<T> FromAngstroms(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)));
 /// <summary>
 	/// Creates a new Offset from a value in Foot.
 	/// </summary>
 	/// <param name="value">The value in Foot.</param>
 	/// <returns>A new Offset instance.</returns>
-	public static Offset<T> FromFoot(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)));
+	public static Offset<T> FromFeet(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)));
 /// <summary>
 	/// Creates a new Offset from a value in Inch.
 	/// </summary>
 	/// <param name="value">The value in Inch.</param>
 	/// <returns>A new Offset instance.</returns>
-	public static Offset<T> FromInch(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)));
+	public static Offset<T> FromInches(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)));
 /// <summary>
 	/// Creates a new Offset from a value in Yard.
 	/// </summary>
 	/// <param name="value">The value in Yard.</param>
 	/// <returns>A new Offset instance.</returns>
-	public static Offset<T> FromYard(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)));
+	public static Offset<T> FromYards(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)));
 /// <summary>
 	/// Creates a new Offset from a value in Mile.
 	/// </summary>
 	/// <param name="value">The value in Mile.</param>
 	/// <returns>A new Offset instance.</returns>
-	public static Offset<T> FromMile(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)));
+	public static Offset<T> FromMiles(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)));
 /// <summary>Implicit conversion to Displacement1D.</summary>
 	public static implicit operator Displacement1D<T>(Offset<T> value) => Displacement1D<T>.Create(value.Value);
 /// <summary>Explicit conversion from Displacement1D.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/OpticalPower.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/OpticalPower.g.cs
@@ -23,7 +23,7 @@ public record OpticalPower<T> : PhysicalQuantity<OpticalPower<T>, T>, IVector0<O
 	/// <param name="value">The value in Diopter.</param>
 	/// <returns>A new <see cref="OpticalPower{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static OpticalPower<T> FromDiopter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static OpticalPower<T> FromDiopters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two OpticalPower values, returning the absolute difference as a non-negative OpticalPower.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Perimeter.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Perimeter.g.cs
@@ -24,77 +24,77 @@ public record Perimeter<T> : PhysicalQuantity<Perimeter<T>, T>, IVector0<Perimet
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new Perimeter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Perimeter<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Perimeter<T> FromMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Perimeter from a value in Kilometer.
 	/// </summary>
 	/// <param name="value">The value in Kilometer.</param>
 	/// <returns>A new Perimeter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Perimeter<T> FromKilometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+	public static Perimeter<T> FromKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
 /// <summary>
 	/// Creates a new Perimeter from a value in Centimeter.
 	/// </summary>
 	/// <param name="value">The value in Centimeter.</param>
 	/// <returns>A new Perimeter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Perimeter<T> FromCentimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
+	public static Perimeter<T> FromCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
 /// <summary>
 	/// Creates a new Perimeter from a value in Millimeter.
 	/// </summary>
 	/// <param name="value">The value in Millimeter.</param>
 	/// <returns>A new Perimeter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Perimeter<T> FromMillimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Perimeter<T> FromMillimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new Perimeter from a value in Micrometer.
 	/// </summary>
 	/// <param name="value">The value in Micrometer.</param>
 	/// <returns>A new Perimeter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Perimeter<T> FromMicrometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Perimeter<T> FromMicrometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new Perimeter from a value in Nanometer.
 	/// </summary>
 	/// <param name="value">The value in Nanometer.</param>
 	/// <returns>A new Perimeter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Perimeter<T> FromNanometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+	public static Perimeter<T> FromNanometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
 /// <summary>
 	/// Creates a new Perimeter from a value in Angstrom.
 	/// </summary>
 	/// <param name="value">The value in Angstrom.</param>
 	/// <returns>A new Perimeter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Perimeter<T> FromAngstrom(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
+	public static Perimeter<T> FromAngstroms(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Perimeter from a value in Foot.
 	/// </summary>
 	/// <param name="value">The value in Foot.</param>
 	/// <returns>A new Perimeter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Perimeter<T> FromFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
+	public static Perimeter<T> FromFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Perimeter from a value in Inch.
 	/// </summary>
 	/// <param name="value">The value in Inch.</param>
 	/// <returns>A new Perimeter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Perimeter<T> FromInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
+	public static Perimeter<T> FromInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Perimeter from a value in Yard.
 	/// </summary>
 	/// <param name="value">The value in Yard.</param>
 	/// <returns>A new Perimeter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Perimeter<T> FromYard(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
+	public static Perimeter<T> FromYards(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Perimeter from a value in Mile.
 	/// </summary>
 	/// <param name="value">The value in Mile.</param>
 	/// <returns>A new Perimeter instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Perimeter<T> FromMile(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
+	public static Perimeter<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Perimeter<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Period.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Period.g.cs
@@ -24,49 +24,49 @@ public record Period<T> : PhysicalQuantity<Period<T>, T>, IVector0<Period<T>, T>
 	/// <param name="value">The value in Second.</param>
 	/// <returns>A new Period instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Period<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Period<T> FromSeconds(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Period from a value in Millisecond.
 	/// </summary>
 	/// <param name="value">The value in Millisecond.</param>
 	/// <returns>A new Period instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Period<T> FromMillisecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Period<T> FromMilliseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new Period from a value in Microsecond.
 	/// </summary>
 	/// <param name="value">The value in Microsecond.</param>
 	/// <returns>A new Period instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Period<T> FromMicrosecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Period<T> FromMicroseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new Period from a value in Minute.
 	/// </summary>
 	/// <param name="value">The value in Minute.</param>
 	/// <returns>A new Period instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Period<T> FromMinute(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
+	public static Period<T> FromMinutes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new Period from a value in Hour.
 	/// </summary>
 	/// <param name="value">The value in Hour.</param>
 	/// <returns>A new Period instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Period<T> FromHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
+	public static Period<T> FromHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new Period from a value in Day.
 	/// </summary>
 	/// <param name="value">The value in Day.</param>
 	/// <returns>A new Period instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Period<T> FromDay(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
+	public static Period<T> FromDays(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new Period from a value in Year.
 	/// </summary>
 	/// <param name="value">The value in Year.</param>
 	/// <returns>A new Period instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Period<T> FromYear(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
+	public static Period<T> FromYears(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>Implicit conversion to Duration.</summary>
 	public static implicit operator Duration<T>(Period<T> value) => Duration<T>.Create(value.Value);
 /// <summary>Explicit conversion from Duration.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Phase.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Phase.g.cs
@@ -23,13 +23,13 @@ public record Phase<T> : PhysicalQuantity<Phase<T>, T>, IVector1<Phase<T>, T>
 	/// </summary>
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new Phase instance.</returns>
-	public static Phase<T> FromRadian(T value) => Create(value);
+	public static Phase<T> FromRadians(T value) => Create(value);
 /// <summary>
 	/// Creates a new Phase from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new Phase instance.</returns>
-	public static Phase<T> FromDegree(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
+	public static Phase<T> FromDegrees(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
 /// <summary>Implicit conversion to SignedAngle.</summary>
 	public static implicit operator SignedAngle<T>(Phase<T> value) => SignedAngle<T>.Create(value.Value);
 /// <summary>Explicit conversion from SignedAngle.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/PotentialEnergy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/PotentialEnergy.g.cs
@@ -24,28 +24,28 @@ public record PotentialEnergy<T> : PhysicalQuantity<PotentialEnergy<T>, T>, IVec
 	/// <param name="value">The value in Joule.</param>
 	/// <returns>A new PotentialEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static PotentialEnergy<T> FromJoule(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static PotentialEnergy<T> FromJoules(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new PotentialEnergy from a value in ElectronVolt.
 	/// </summary>
 	/// <param name="value">The value in ElectronVolt.</param>
 	/// <returns>A new PotentialEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static PotentialEnergy<T> FromElectronVolt(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ElectronVoltToJoules)), nameof(value)));
+	public static PotentialEnergy<T> FromElectronVolts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ElectronVoltToJoules)), nameof(value)));
 /// <summary>
 	/// Creates a new PotentialEnergy from a value in Calorie.
 	/// </summary>
 	/// <param name="value">The value in Calorie.</param>
 	/// <returns>A new PotentialEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static PotentialEnergy<T> FromCalorie(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
+	public static PotentialEnergy<T> FromCalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
 /// <summary>
 	/// Creates a new PotentialEnergy from a value in KilowattHour.
 	/// </summary>
 	/// <param name="value">The value in KilowattHour.</param>
 	/// <returns>A new PotentialEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static PotentialEnergy<T> FromKilowattHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
+	public static PotentialEnergy<T> FromKilowattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
 /// <summary>Implicit conversion to Energy.</summary>
 	public static implicit operator Energy<T>(PotentialEnergy<T> value) => Energy<T>.Create(value.Value);
 /// <summary>Explicit conversion from Energy.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Power.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Power.g.cs
@@ -23,7 +23,7 @@ public record Power<T> : PhysicalQuantity<Power<T>, T>, IVector0<Power<T>, T>
 	/// <param name="value">The value in Watt.</param>
 	/// <returns>A new <see cref="Power{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Power<T> FromWatt(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Power<T> FromWatts(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Power{T}"/> from a value in Horsepower.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Pressure.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Pressure.g.cs
@@ -23,21 +23,21 @@ public record Pressure<T> : PhysicalQuantity<Pressure<T>, T>, IVector0<Pressure<
 	/// <param name="value">The value in Pascal.</param>
 	/// <returns>A new <see cref="Pressure{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Pressure<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Pressure<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Pressure{T}"/> from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
 	/// <returns>A new <see cref="Pressure{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Pressure<T> FromBar(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
+	public static Pressure<T> FromBars(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Pressure{T}"/> from a value in Atmosphere.
 	/// </summary>
 	/// <param name="value">The value in Atmosphere.</param>
 	/// <returns>A new <see cref="Pressure{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Pressure<T> FromAtmosphere(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
+	public static Pressure<T> FromAtmospheres(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Pressure{T}"/> from a value in Psi.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/RadioactiveActivity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/RadioactiveActivity.g.cs
@@ -23,7 +23,7 @@ public record RadioactiveActivity<T> : PhysicalQuantity<RadioactiveActivity<T>, 
 	/// <param name="value">The value in Becquerel.</param>
 	/// <returns>A new <see cref="RadioactiveActivity{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static RadioactiveActivity<T> FromBecquerel(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static RadioactiveActivity<T> FromBecquerels(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two RadioactiveActivity values, returning the absolute difference as a non-negative RadioactiveActivity.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Radius.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Radius.g.cs
@@ -24,77 +24,77 @@ public record Radius<T> : PhysicalQuantity<Radius<T>, T>, IVector0<Radius<T>, T>
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new Radius instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Radius<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Radius<T> FromMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Radius from a value in Kilometer.
 	/// </summary>
 	/// <param name="value">The value in Kilometer.</param>
 	/// <returns>A new Radius instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Radius<T> FromKilometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+	public static Radius<T> FromKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
 /// <summary>
 	/// Creates a new Radius from a value in Centimeter.
 	/// </summary>
 	/// <param name="value">The value in Centimeter.</param>
 	/// <returns>A new Radius instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Radius<T> FromCentimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
+	public static Radius<T> FromCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
 /// <summary>
 	/// Creates a new Radius from a value in Millimeter.
 	/// </summary>
 	/// <param name="value">The value in Millimeter.</param>
 	/// <returns>A new Radius instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Radius<T> FromMillimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Radius<T> FromMillimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new Radius from a value in Micrometer.
 	/// </summary>
 	/// <param name="value">The value in Micrometer.</param>
 	/// <returns>A new Radius instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Radius<T> FromMicrometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Radius<T> FromMicrometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new Radius from a value in Nanometer.
 	/// </summary>
 	/// <param name="value">The value in Nanometer.</param>
 	/// <returns>A new Radius instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Radius<T> FromNanometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+	public static Radius<T> FromNanometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
 /// <summary>
 	/// Creates a new Radius from a value in Angstrom.
 	/// </summary>
 	/// <param name="value">The value in Angstrom.</param>
 	/// <returns>A new Radius instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Radius<T> FromAngstrom(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
+	public static Radius<T> FromAngstroms(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Radius from a value in Foot.
 	/// </summary>
 	/// <param name="value">The value in Foot.</param>
 	/// <returns>A new Radius instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Radius<T> FromFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
+	public static Radius<T> FromFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Radius from a value in Inch.
 	/// </summary>
 	/// <param name="value">The value in Inch.</param>
 	/// <returns>A new Radius instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Radius<T> FromInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
+	public static Radius<T> FromInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Radius from a value in Yard.
 	/// </summary>
 	/// <param name="value">The value in Yard.</param>
 	/// <returns>A new Radius instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Radius<T> FromYard(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
+	public static Radius<T> FromYards(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Radius from a value in Mile.
 	/// </summary>
 	/// <param name="value">The value in Mile.</param>
 	/// <returns>A new Radius instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Radius<T> FromMile(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
+	public static Radius<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Radius<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Ratio.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Ratio.g.cs
@@ -30,14 +30,14 @@ public record Ratio<T> : PhysicalQuantity<Ratio<T>, T>, IVector0<Ratio<T>, T>
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new <see cref="Ratio{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Ratio<T> FromRadian(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Ratio<T> FromRadians(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Ratio{T}"/> from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new <see cref="Ratio{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Ratio<T> FromDegree(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
+	public static Ratio<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>
 	/// Subtracts two Ratio values, returning the absolute difference as a non-negative Ratio.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/RefractiveIndex.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/RefractiveIndex.g.cs
@@ -31,14 +31,14 @@ public record RefractiveIndex<T> : PhysicalQuantity<RefractiveIndex<T>, T>, IVec
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new RefractiveIndex instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static RefractiveIndex<T> FromRadian(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static RefractiveIndex<T> FromRadians(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new RefractiveIndex from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new RefractiveIndex instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static RefractiveIndex<T> FromDegree(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
+	public static RefractiveIndex<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>Implicit conversion to Ratio.</summary>
 	public static implicit operator Ratio<T>(RefractiveIndex<T> value) => Ratio<T>.Create(value.Value);
 /// <summary>Explicit conversion from Ratio.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Resistance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Resistance.g.cs
@@ -23,7 +23,7 @@ public record Resistance<T> : PhysicalQuantity<Resistance<T>, T>, IVector0<Resis
 	/// <param name="value">The value in Ohm.</param>
 	/// <returns>A new <see cref="Resistance{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Resistance<T> FromOhm(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Resistance<T> FromOhms(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two Resistance values, returning the absolute difference as a non-negative Resistance.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReverberationTime.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReverberationTime.g.cs
@@ -24,49 +24,49 @@ public record ReverberationTime<T> : PhysicalQuantity<ReverberationTime<T>, T>, 
 	/// <param name="value">The value in Second.</param>
 	/// <returns>A new ReverberationTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ReverberationTime<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static ReverberationTime<T> FromSeconds(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new ReverberationTime from a value in Millisecond.
 	/// </summary>
 	/// <param name="value">The value in Millisecond.</param>
 	/// <returns>A new ReverberationTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ReverberationTime<T> FromMillisecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static ReverberationTime<T> FromMilliseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new ReverberationTime from a value in Microsecond.
 	/// </summary>
 	/// <param name="value">The value in Microsecond.</param>
 	/// <returns>A new ReverberationTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ReverberationTime<T> FromMicrosecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static ReverberationTime<T> FromMicroseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new ReverberationTime from a value in Minute.
 	/// </summary>
 	/// <param name="value">The value in Minute.</param>
 	/// <returns>A new ReverberationTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ReverberationTime<T> FromMinute(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
+	public static ReverberationTime<T> FromMinutes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new ReverberationTime from a value in Hour.
 	/// </summary>
 	/// <param name="value">The value in Hour.</param>
 	/// <returns>A new ReverberationTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ReverberationTime<T> FromHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
+	public static ReverberationTime<T> FromHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new ReverberationTime from a value in Day.
 	/// </summary>
 	/// <param name="value">The value in Day.</param>
 	/// <returns>A new ReverberationTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ReverberationTime<T> FromDay(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
+	public static ReverberationTime<T> FromDays(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new ReverberationTime from a value in Year.
 	/// </summary>
 	/// <param name="value">The value in Year.</param>
 	/// <returns>A new ReverberationTime instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ReverberationTime<T> FromYear(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
+	public static ReverberationTime<T> FromYears(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>Implicit conversion to Duration.</summary>
 	public static implicit operator Duration<T>(ReverberationTime<T> value) => Duration<T>.Create(value.Value);
 /// <summary>Explicit conversion from Duration.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReynoldsNumber.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReynoldsNumber.g.cs
@@ -31,14 +31,14 @@ public record ReynoldsNumber<T> : PhysicalQuantity<ReynoldsNumber<T>, T>, IVecto
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new ReynoldsNumber instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ReynoldsNumber<T> FromRadian(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static ReynoldsNumber<T> FromRadians(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new ReynoldsNumber from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new ReynoldsNumber instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ReynoldsNumber<T> FromDegree(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
+	public static ReynoldsNumber<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>Implicit conversion to Ratio.</summary>
 	public static implicit operator Ratio<T>(ReynoldsNumber<T> value) => Ratio<T>.Create(value.Value);
 /// <summary>Explicit conversion from Ratio.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Rotation.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Rotation.g.cs
@@ -23,13 +23,13 @@ public record Rotation<T> : PhysicalQuantity<Rotation<T>, T>, IVector1<Rotation<
 	/// </summary>
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new Rotation instance.</returns>
-	public static Rotation<T> FromRadian(T value) => Create(value);
+	public static Rotation<T> FromRadians(T value) => Create(value);
 /// <summary>
 	/// Creates a new Rotation from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new Rotation instance.</returns>
-	public static Rotation<T> FromDegree(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
+	public static Rotation<T> FromDegrees(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
 /// <summary>Implicit conversion to SignedAngle.</summary>
 	public static implicit operator SignedAngle<T>(Rotation<T> value) => SignedAngle<T>.Create(value.Value);
 /// <summary>Explicit conversion from SignedAngle.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ShearModulus.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ShearModulus.g.cs
@@ -24,21 +24,21 @@ public record ShearModulus<T> : PhysicalQuantity<ShearModulus<T>, T>, IVector0<S
 	/// <param name="value">The value in Pascal.</param>
 	/// <returns>A new ShearModulus instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ShearModulus<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static ShearModulus<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new ShearModulus from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
 	/// <returns>A new ShearModulus instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ShearModulus<T> FromBar(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
+	public static ShearModulus<T> FromBars(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new ShearModulus from a value in Atmosphere.
 	/// </summary>
 	/// <param name="value">The value in Atmosphere.</param>
 	/// <returns>A new ShearModulus instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ShearModulus<T> FromAtmosphere(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
+	public static ShearModulus<T> FromAtmospheres(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new ShearModulus from a value in Psi.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SignedAngle.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SignedAngle.g.cs
@@ -22,13 +22,13 @@ public record SignedAngle<T> : PhysicalQuantity<SignedAngle<T>, T>, IVector1<Sig
 	/// </summary>
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new <see cref="SignedAngle{T}"/> instance.</returns>
-	public static SignedAngle<T> FromRadian(T value) => Create(value);
+	public static SignedAngle<T> FromRadians(T value) => Create(value);
 /// <summary>
 	/// Creates a new <see cref="SignedAngle{T}"/> from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new <see cref="SignedAngle{T}"/> instance.</returns>
-	public static SignedAngle<T> FromDegree(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
+	public static SignedAngle<T> FromDegrees(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
 /// <summary>
 	/// Gets the magnitude of this quantity as a <see cref="Angle{T}"/>.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SignedRatio.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SignedRatio.g.cs
@@ -28,13 +28,13 @@ public record SignedRatio<T> : PhysicalQuantity<SignedRatio<T>, T>, IVector1<Sig
 	/// </summary>
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new <see cref="SignedRatio{T}"/> instance.</returns>
-	public static SignedRatio<T> FromRadian(T value) => Create(value);
+	public static SignedRatio<T> FromRadians(T value) => Create(value);
 /// <summary>
 	/// Creates a new <see cref="SignedRatio{T}"/> from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new <see cref="SignedRatio{T}"/> instance.</returns>
-	public static SignedRatio<T> FromDegree(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
+	public static SignedRatio<T> FromDegrees(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
 /// <summary>
 	/// Gets the magnitude of this quantity as a <see cref="Ratio{T}"/>.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SpecificGravity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SpecificGravity.g.cs
@@ -31,14 +31,14 @@ public record SpecificGravity<T> : PhysicalQuantity<SpecificGravity<T>, T>, IVec
 	/// <param name="value">The value in Radian.</param>
 	/// <returns>A new SpecificGravity instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static SpecificGravity<T> FromRadian(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static SpecificGravity<T> FromRadians(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new SpecificGravity from a value in Degree.
 	/// </summary>
 	/// <param name="value">The value in Degree.</param>
 	/// <returns>A new SpecificGravity instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static SpecificGravity<T> FromDegree(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
+	public static SpecificGravity<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>Implicit conversion to Ratio.</summary>
 	public static implicit operator Ratio<T>(SpecificGravity<T> value) => Ratio<T>.Create(value.Value);
 /// <summary>Explicit conversion from Ratio.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Stress.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Stress.g.cs
@@ -24,21 +24,21 @@ public record Stress<T> : PhysicalQuantity<Stress<T>, T>, IVector0<Stress<T>, T>
 	/// <param name="value">The value in Pascal.</param>
 	/// <returns>A new Stress instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Stress<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Stress<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Stress from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
 	/// <returns>A new Stress instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Stress<T> FromBar(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
+	public static Stress<T> FromBars(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new Stress from a value in Atmosphere.
 	/// </summary>
 	/// <param name="value">The value in Atmosphere.</param>
 	/// <returns>A new Stress instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Stress<T> FromAtmosphere(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
+	public static Stress<T> FromAtmospheres(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new Stress from a value in Psi.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SurfaceArea.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SurfaceArea.g.cs
@@ -24,21 +24,21 @@ public record SurfaceArea<T> : PhysicalQuantity<SurfaceArea<T>, T>, IVector0<Sur
 	/// <param name="value">The value in SquareMeter.</param>
 	/// <returns>A new SurfaceArea instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static SurfaceArea<T> FromSquareMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static SurfaceArea<T> FromSquareMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new SurfaceArea from a value in SquareFoot.
 	/// </summary>
 	/// <param name="value">The value in SquareFoot.</param>
 	/// <returns>A new SurfaceArea instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static SurfaceArea<T> FromSquareFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareFootToSquareMeters)), nameof(value)));
+	public static SurfaceArea<T> FromSquareFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareFootToSquareMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new SurfaceArea from a value in SquareInch.
 	/// </summary>
 	/// <param name="value">The value in SquareInch.</param>
 	/// <returns>A new SurfaceArea instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static SurfaceArea<T> FromSquareInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareInchToSquareMeters)), nameof(value)));
+	public static SurfaceArea<T> FromSquareInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareInchToSquareMeters)), nameof(value)));
 /// <summary>Implicit conversion to Area.</summary>
 	public static implicit operator Area<T>(SurfaceArea<T> value) => Area<T>.Create(value.Value);
 /// <summary>Explicit conversion from Area.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Temperature.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Temperature.g.cs
@@ -23,7 +23,7 @@ public record Temperature<T> : PhysicalQuantity<Temperature<T>, T>, IVector0<Tem
 	/// <param name="value">The value in Kelvin.</param>
 	/// <returns>A new <see cref="Temperature{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Temperature<T> FromKelvin(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Temperature<T> FromKelvins(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Temperature{T}"/> from a value in Celsius.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TemperatureDelta.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TemperatureDelta.g.cs
@@ -22,7 +22,7 @@ public record TemperatureDelta<T> : PhysicalQuantity<TemperatureDelta<T>, T>, IV
 	/// </summary>
 	/// <param name="value">The value in Kelvin.</param>
 	/// <returns>A new <see cref="TemperatureDelta{T}"/> instance.</returns>
-	public static TemperatureDelta<T> FromKelvin(T value) => Create(value);
+	public static TemperatureDelta<T> FromKelvins(T value) => Create(value);
 /// <summary>
 	/// Creates a new <see cref="TemperatureDelta{T}"/> from a value in Celsius.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TemperatureDrop.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TemperatureDrop.g.cs
@@ -23,7 +23,7 @@ public record TemperatureDrop<T> : PhysicalQuantity<TemperatureDrop<T>, T>, IVec
 	/// </summary>
 	/// <param name="value">The value in Kelvin.</param>
 	/// <returns>A new TemperatureDrop instance.</returns>
-	public static TemperatureDrop<T> FromKelvin(T value) => Create(value);
+	public static TemperatureDrop<T> FromKelvins(T value) => Create(value);
 /// <summary>
 	/// Creates a new TemperatureDrop from a value in Celsius.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TemperatureRise.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TemperatureRise.g.cs
@@ -23,7 +23,7 @@ public record TemperatureRise<T> : PhysicalQuantity<TemperatureRise<T>, T>, IVec
 	/// </summary>
 	/// <param name="value">The value in Kelvin.</param>
 	/// <returns>A new TemperatureRise instance.</returns>
-	public static TemperatureRise<T> FromKelvin(T value) => Create(value);
+	public static TemperatureRise<T> FromKelvins(T value) => Create(value);
 /// <summary>
 	/// Creates a new TemperatureRise from a value in Celsius.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Tension.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Tension.g.cs
@@ -24,7 +24,7 @@ public record Tension<T> : PhysicalQuantity<Tension<T>, T>, IVector0<Tension<T>,
 	/// <param name="value">The value in Newton.</param>
 	/// <returns>A new Tension instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Tension<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Tension<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(Tension<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ThermalEnergy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ThermalEnergy.g.cs
@@ -24,28 +24,28 @@ public record ThermalEnergy<T> : PhysicalQuantity<ThermalEnergy<T>, T>, IVector0
 	/// <param name="value">The value in Joule.</param>
 	/// <returns>A new ThermalEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ThermalEnergy<T> FromJoule(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static ThermalEnergy<T> FromJoules(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new ThermalEnergy from a value in ElectronVolt.
 	/// </summary>
 	/// <param name="value">The value in ElectronVolt.</param>
 	/// <returns>A new ThermalEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ThermalEnergy<T> FromElectronVolt(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ElectronVoltToJoules)), nameof(value)));
+	public static ThermalEnergy<T> FromElectronVolts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ElectronVoltToJoules)), nameof(value)));
 /// <summary>
 	/// Creates a new ThermalEnergy from a value in Calorie.
 	/// </summary>
 	/// <param name="value">The value in Calorie.</param>
 	/// <returns>A new ThermalEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ThermalEnergy<T> FromCalorie(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
+	public static ThermalEnergy<T> FromCalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
 /// <summary>
 	/// Creates a new ThermalEnergy from a value in KilowattHour.
 	/// </summary>
 	/// <param name="value">The value in KilowattHour.</param>
 	/// <returns>A new ThermalEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static ThermalEnergy<T> FromKilowattHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
+	public static ThermalEnergy<T> FromKilowattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
 /// <summary>Implicit conversion to Energy.</summary>
 	public static implicit operator Energy<T>(ThermalEnergy<T> value) => Energy<T>.Create(value.Value);
 /// <summary>Explicit conversion from Energy.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Thickness.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Thickness.g.cs
@@ -24,77 +24,77 @@ public record Thickness<T> : PhysicalQuantity<Thickness<T>, T>, IVector0<Thickne
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new Thickness instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Thickness<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Thickness<T> FromMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Thickness from a value in Kilometer.
 	/// </summary>
 	/// <param name="value">The value in Kilometer.</param>
 	/// <returns>A new Thickness instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Thickness<T> FromKilometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+	public static Thickness<T> FromKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
 /// <summary>
 	/// Creates a new Thickness from a value in Centimeter.
 	/// </summary>
 	/// <param name="value">The value in Centimeter.</param>
 	/// <returns>A new Thickness instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Thickness<T> FromCentimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
+	public static Thickness<T> FromCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
 /// <summary>
 	/// Creates a new Thickness from a value in Millimeter.
 	/// </summary>
 	/// <param name="value">The value in Millimeter.</param>
 	/// <returns>A new Thickness instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Thickness<T> FromMillimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Thickness<T> FromMillimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new Thickness from a value in Micrometer.
 	/// </summary>
 	/// <param name="value">The value in Micrometer.</param>
 	/// <returns>A new Thickness instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Thickness<T> FromMicrometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Thickness<T> FromMicrometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new Thickness from a value in Nanometer.
 	/// </summary>
 	/// <param name="value">The value in Nanometer.</param>
 	/// <returns>A new Thickness instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Thickness<T> FromNanometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+	public static Thickness<T> FromNanometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
 /// <summary>
 	/// Creates a new Thickness from a value in Angstrom.
 	/// </summary>
 	/// <param name="value">The value in Angstrom.</param>
 	/// <returns>A new Thickness instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Thickness<T> FromAngstrom(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
+	public static Thickness<T> FromAngstroms(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Thickness from a value in Foot.
 	/// </summary>
 	/// <param name="value">The value in Foot.</param>
 	/// <returns>A new Thickness instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Thickness<T> FromFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
+	public static Thickness<T> FromFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Thickness from a value in Inch.
 	/// </summary>
 	/// <param name="value">The value in Inch.</param>
 	/// <returns>A new Thickness instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Thickness<T> FromInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
+	public static Thickness<T> FromInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Thickness from a value in Yard.
 	/// </summary>
 	/// <param name="value">The value in Yard.</param>
 	/// <returns>A new Thickness instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Thickness<T> FromYard(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
+	public static Thickness<T> FromYards(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Thickness from a value in Mile.
 	/// </summary>
 	/// <param name="value">The value in Mile.</param>
 	/// <returns>A new Thickness instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Thickness<T> FromMile(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
+	public static Thickness<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Thickness<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Thrust.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Thrust.g.cs
@@ -24,7 +24,7 @@ public record Thrust<T> : PhysicalQuantity<Thrust<T>, T>, IVector0<Thrust<T>, T>
 	/// <param name="value">The value in Newton.</param>
 	/// <returns>A new Thrust instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Thrust<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Thrust<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(Thrust<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TimeConstant.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TimeConstant.g.cs
@@ -24,49 +24,49 @@ public record TimeConstant<T> : PhysicalQuantity<TimeConstant<T>, T>, IVector0<T
 	/// <param name="value">The value in Second.</param>
 	/// <returns>A new TimeConstant instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static TimeConstant<T> FromSecond(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static TimeConstant<T> FromSeconds(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new TimeConstant from a value in Millisecond.
 	/// </summary>
 	/// <param name="value">The value in Millisecond.</param>
 	/// <returns>A new TimeConstant instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static TimeConstant<T> FromMillisecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static TimeConstant<T> FromMilliseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new TimeConstant from a value in Microsecond.
 	/// </summary>
 	/// <param name="value">The value in Microsecond.</param>
 	/// <returns>A new TimeConstant instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static TimeConstant<T> FromMicrosecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static TimeConstant<T> FromMicroseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new TimeConstant from a value in Minute.
 	/// </summary>
 	/// <param name="value">The value in Minute.</param>
 	/// <returns>A new TimeConstant instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static TimeConstant<T> FromMinute(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
+	public static TimeConstant<T> FromMinutes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MinuteToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new TimeConstant from a value in Hour.
 	/// </summary>
 	/// <param name="value">The value in Hour.</param>
 	/// <returns>A new TimeConstant instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static TimeConstant<T> FromHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
+	public static TimeConstant<T> FromHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HourToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new TimeConstant from a value in Day.
 	/// </summary>
 	/// <param name="value">The value in Day.</param>
 	/// <returns>A new TimeConstant instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static TimeConstant<T> FromDay(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
+	public static TimeConstant<T> FromDays(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DayToSeconds)), nameof(value)));
 /// <summary>
 	/// Creates a new TimeConstant from a value in Year.
 	/// </summary>
 	/// <param name="value">The value in Year.</param>
 	/// <returns>A new TimeConstant instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static TimeConstant<T> FromYear(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
+	public static TimeConstant<T> FromYears(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>Implicit conversion to Duration.</summary>
 	public static implicit operator Duration<T>(TimeConstant<T> value) => Duration<T>.Create(value.Value);
 /// <summary>Explicit conversion from Duration.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Torque1D.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Torque1D.g.cs
@@ -22,13 +22,13 @@ public record Torque1D<T> : PhysicalQuantity<Torque1D<T>, T>, IVector1<Torque1D<
 	/// </summary>
 	/// <param name="value">The value in NewtonMeter.</param>
 	/// <returns>A new <see cref="Torque1D{T}"/> instance.</returns>
-	public static Torque1D<T> FromNewtonMeter(T value) => Create(value);
+	public static Torque1D<T> FromNewtonMeters(T value) => Create(value);
 /// <summary>
 	/// Creates a new <see cref="Torque1D{T}"/> from a value in PoundFoot.
 	/// </summary>
 	/// <param name="value">The value in PoundFoot.</param>
 	/// <returns>A new <see cref="Torque1D{T}"/> instance.</returns>
-	public static Torque1D<T> FromPoundFoot(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.PoundFootToNewtonMeters)));
+	public static Torque1D<T> FromPoundFeet(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.PoundFootToNewtonMeters)));
 /// <summary>
 	/// Gets the magnitude of this quantity as a <see cref="TorqueMagnitude{T}"/>.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TorqueMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TorqueMagnitude.g.cs
@@ -23,14 +23,14 @@ public record TorqueMagnitude<T> : PhysicalQuantity<TorqueMagnitude<T>, T>, IVec
 	/// <param name="value">The value in NewtonMeter.</param>
 	/// <returns>A new <see cref="TorqueMagnitude{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static TorqueMagnitude<T> FromNewtonMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static TorqueMagnitude<T> FromNewtonMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="TorqueMagnitude{T}"/> from a value in PoundFoot.
 	/// </summary>
 	/// <param name="value">The value in PoundFoot.</param>
 	/// <returns>A new <see cref="TorqueMagnitude{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static TorqueMagnitude<T> FromPoundFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundFootToNewtonMeters)), nameof(value)));
+	public static TorqueMagnitude<T> FromPoundFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundFootToNewtonMeters)), nameof(value)));
 /// <summary>
 	/// Subtracts two TorqueMagnitude values, returning the absolute difference as a non-negative TorqueMagnitude.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Voltage.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Voltage.g.cs
@@ -22,7 +22,7 @@ public record Voltage<T> : PhysicalQuantity<Voltage<T>, T>, IVector1<Voltage<T>,
 	/// </summary>
 	/// <param name="value">The value in Volt.</param>
 	/// <returns>A new <see cref="Voltage{T}"/> instance.</returns>
-	public static Voltage<T> FromVolt(T value) => Create(value);
+	public static Voltage<T> FromVolts(T value) => Create(value);
 /// <summary>
 	/// Gets the magnitude of this quantity as a <see cref="VoltageMagnitude{T}"/>.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VoltageDrop.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VoltageDrop.g.cs
@@ -24,7 +24,7 @@ public record VoltageDrop<T> : PhysicalQuantity<VoltageDrop<T>, T>, IVector0<Vol
 	/// <param name="value">The value in Volt.</param>
 	/// <returns>A new VoltageDrop instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static VoltageDrop<T> FromVolt(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static VoltageDrop<T> FromVolts(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to VoltageMagnitude.</summary>
 	public static implicit operator VoltageMagnitude<T>(VoltageDrop<T> value) => VoltageMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from VoltageMagnitude.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VoltageMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VoltageMagnitude.g.cs
@@ -23,7 +23,7 @@ public record VoltageMagnitude<T> : PhysicalQuantity<VoltageMagnitude<T>, T>, IV
 	/// <param name="value">The value in Volt.</param>
 	/// <returns>A new <see cref="VoltageMagnitude{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static VoltageMagnitude<T> FromVolt(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static VoltageMagnitude<T> FromVolts(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Subtracts two VoltageMagnitude values, returning the absolute difference as a non-negative VoltageMagnitude.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Volume.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Volume.g.cs
@@ -23,28 +23,28 @@ public record Volume<T> : PhysicalQuantity<Volume<T>, T>, IVector0<Volume<T>, T>
 	/// <param name="value">The value in CubicMeter.</param>
 	/// <returns>A new <see cref="Volume{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Volume<T> FromCubicMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Volume<T> FromCubicMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Volume{T}"/> from a value in Liter.
 	/// </summary>
 	/// <param name="value">The value in Liter.</param>
 	/// <returns>A new <see cref="Volume{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Volume<T> FromLiter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.LiterToCubicMeters)), nameof(value)));
+	public static Volume<T> FromLiters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.LiterToCubicMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Volume{T}"/> from a value in Milliliter.
 	/// </summary>
 	/// <param name="value">The value in Milliliter.</param>
 	/// <returns>A new <see cref="Volume{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Volume<T> FromMilliliter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Volume<T> FromMilliliters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new <see cref="Volume{T}"/> from a value in Gallon.
 	/// </summary>
 	/// <param name="value">The value in Gallon.</param>
 	/// <returns>A new <see cref="Volume{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Volume<T> FromGallon(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GallonToCubicMeters)), nameof(value)));
+	public static Volume<T> FromGallons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GallonToCubicMeters)), nameof(value)));
 /// <summary>
 	/// Subtracts two Volume values, returning the absolute difference as a non-negative Volume.
 	/// Magnitude subtraction stays a magnitude (per the unified-vector model).

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Wavelength.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Wavelength.g.cs
@@ -24,77 +24,77 @@ public record Wavelength<T> : PhysicalQuantity<Wavelength<T>, T>, IVector0<Wavel
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new Wavelength instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Wavelength<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Wavelength<T> FromMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Wavelength from a value in Kilometer.
 	/// </summary>
 	/// <param name="value">The value in Kilometer.</param>
 	/// <returns>A new Wavelength instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Wavelength<T> FromKilometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+	public static Wavelength<T> FromKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
 /// <summary>
 	/// Creates a new Wavelength from a value in Centimeter.
 	/// </summary>
 	/// <param name="value">The value in Centimeter.</param>
 	/// <returns>A new Wavelength instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Wavelength<T> FromCentimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
+	public static Wavelength<T> FromCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
 /// <summary>
 	/// Creates a new Wavelength from a value in Millimeter.
 	/// </summary>
 	/// <param name="value">The value in Millimeter.</param>
 	/// <returns>A new Wavelength instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Wavelength<T> FromMillimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Wavelength<T> FromMillimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new Wavelength from a value in Micrometer.
 	/// </summary>
 	/// <param name="value">The value in Micrometer.</param>
 	/// <returns>A new Wavelength instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Wavelength<T> FromMicrometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Wavelength<T> FromMicrometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new Wavelength from a value in Nanometer.
 	/// </summary>
 	/// <param name="value">The value in Nanometer.</param>
 	/// <returns>A new Wavelength instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Wavelength<T> FromNanometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+	public static Wavelength<T> FromNanometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
 /// <summary>
 	/// Creates a new Wavelength from a value in Angstrom.
 	/// </summary>
 	/// <param name="value">The value in Angstrom.</param>
 	/// <returns>A new Wavelength instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Wavelength<T> FromAngstrom(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
+	public static Wavelength<T> FromAngstroms(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Wavelength from a value in Foot.
 	/// </summary>
 	/// <param name="value">The value in Foot.</param>
 	/// <returns>A new Wavelength instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Wavelength<T> FromFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
+	public static Wavelength<T> FromFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Wavelength from a value in Inch.
 	/// </summary>
 	/// <param name="value">The value in Inch.</param>
 	/// <returns>A new Wavelength instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Wavelength<T> FromInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
+	public static Wavelength<T> FromInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Wavelength from a value in Yard.
 	/// </summary>
 	/// <param name="value">The value in Yard.</param>
 	/// <returns>A new Wavelength instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Wavelength<T> FromYard(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
+	public static Wavelength<T> FromYards(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Wavelength from a value in Mile.
 	/// </summary>
 	/// <param name="value">The value in Mile.</param>
 	/// <returns>A new Wavelength instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Wavelength<T> FromMile(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
+	public static Wavelength<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Wavelength<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Weight.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Weight.g.cs
@@ -24,7 +24,7 @@ public record Weight<T> : PhysicalQuantity<Weight<T>, T>, IVector0<Weight<T>, T>
 	/// <param name="value">The value in Newton.</param>
 	/// <returns>A new Weight instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Weight<T> FromNewton(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Weight<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>Implicit conversion to ForceMagnitude.</summary>
 	public static implicit operator ForceMagnitude<T>(Weight<T> value) => ForceMagnitude<T>.Create(value.Value);
 /// <summary>Explicit conversion from ForceMagnitude.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Width.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Width.g.cs
@@ -24,77 +24,77 @@ public record Width<T> : PhysicalQuantity<Width<T>, T>, IVector0<Width<T>, T>
 	/// <param name="value">The value in Meter.</param>
 	/// <returns>A new Width instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Width<T> FromMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Width<T> FromMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Width from a value in Kilometer.
 	/// </summary>
 	/// <param name="value">The value in Kilometer.</param>
 	/// <returns>A new Width instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Width<T> FromKilometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+	public static Width<T> FromKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
 /// <summary>
 	/// Creates a new Width from a value in Centimeter.
 	/// </summary>
 	/// <param name="value">The value in Centimeter.</param>
 	/// <returns>A new Width instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Width<T> FromCentimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
+	public static Width<T> FromCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Centi)), nameof(value)));
 /// <summary>
 	/// Creates a new Width from a value in Millimeter.
 	/// </summary>
 	/// <param name="value">The value in Millimeter.</param>
 	/// <returns>A new Width instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Width<T> FromMillimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+	public static Width<T> FromMillimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
 	/// Creates a new Width from a value in Micrometer.
 	/// </summary>
 	/// <param name="value">The value in Micrometer.</param>
 	/// <returns>A new Width instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Width<T> FromMicrometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+	public static Width<T> FromMicrometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
 /// <summary>
 	/// Creates a new Width from a value in Nanometer.
 	/// </summary>
 	/// <param name="value">The value in Nanometer.</param>
 	/// <returns>A new Width instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Width<T> FromNanometer(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+	public static Width<T> FromNanometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
 /// <summary>
 	/// Creates a new Width from a value in Angstrom.
 	/// </summary>
 	/// <param name="value">The value in Angstrom.</param>
 	/// <returns>A new Width instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Width<T> FromAngstrom(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
+	public static Width<T> FromAngstroms(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AngstromToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Width from a value in Foot.
 	/// </summary>
 	/// <param name="value">The value in Foot.</param>
 	/// <returns>A new Width instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Width<T> FromFoot(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
+	public static Width<T> FromFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Width from a value in Inch.
 	/// </summary>
 	/// <param name="value">The value in Inch.</param>
 	/// <returns>A new Width instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Width<T> FromInch(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
+	public static Width<T> FromInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.InchesToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Width from a value in Yard.
 	/// </summary>
 	/// <param name="value">The value in Yard.</param>
 	/// <returns>A new Width instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Width<T> FromYard(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
+	public static Width<T> FromYards(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YardToMeters)), nameof(value)));
 /// <summary>
 	/// Creates a new Width from a value in Mile.
 	/// </summary>
 	/// <param name="value">The value in Mile.</param>
 	/// <returns>A new Width instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Width<T> FromMile(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
+	public static Width<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>Implicit conversion to Length.</summary>
 	public static implicit operator Length<T>(Width<T> value) => Length<T>.Create(value.Value);
 /// <summary>Explicit conversion from Length.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Work.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Work.g.cs
@@ -24,28 +24,28 @@ public record Work<T> : PhysicalQuantity<Work<T>, T>, IVector0<Work<T>, T>
 	/// <param name="value">The value in Joule.</param>
 	/// <returns>A new Work instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Work<T> FromJoule(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static Work<T> FromJoules(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new Work from a value in ElectronVolt.
 	/// </summary>
 	/// <param name="value">The value in ElectronVolt.</param>
 	/// <returns>A new Work instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Work<T> FromElectronVolt(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ElectronVoltToJoules)), nameof(value)));
+	public static Work<T> FromElectronVolts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ElectronVoltToJoules)), nameof(value)));
 /// <summary>
 	/// Creates a new Work from a value in Calorie.
 	/// </summary>
 	/// <param name="value">The value in Calorie.</param>
 	/// <returns>A new Work instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Work<T> FromCalorie(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
+	public static Work<T> FromCalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
 /// <summary>
 	/// Creates a new Work from a value in KilowattHour.
 	/// </summary>
 	/// <param name="value">The value in KilowattHour.</param>
 	/// <returns>A new Work instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static Work<T> FromKilowattHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
+	public static Work<T> FromKilowattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
 /// <summary>Implicit conversion to Energy.</summary>
 	public static implicit operator Energy<T>(Work<T> value) => Energy<T>.Create(value.Value);
 /// <summary>Explicit conversion from Energy.</summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/YoungsModulus.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/YoungsModulus.g.cs
@@ -24,21 +24,21 @@ public record YoungsModulus<T> : PhysicalQuantity<YoungsModulus<T>, T>, IVector0
 	/// <param name="value">The value in Pascal.</param>
 	/// <returns>A new YoungsModulus instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static YoungsModulus<T> FromPascal(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
+	public static YoungsModulus<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
 	/// Creates a new YoungsModulus from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
 	/// <returns>A new YoungsModulus instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static YoungsModulus<T> FromBar(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
+	public static YoungsModulus<T> FromBars(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BarToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new YoungsModulus from a value in Atmosphere.
 	/// </summary>
 	/// <param name="value">The value in Atmosphere.</param>
 	/// <returns>A new YoungsModulus instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
-	public static YoungsModulus<T> FromAtmosphere(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
+	public static YoungsModulus<T> FromAtmospheres(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtmosphereToPascals)), nameof(value)));
 /// <summary>
 	/// Creates a new YoungsModulus from a value in Psi.
 	/// </summary>

--- a/Semantics.SourceGenerators/Generators/QuantitiesGenerator.cs
+++ b/Semantics.SourceGenerators/Generators/QuantitiesGenerator.cs
@@ -473,6 +473,16 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 				? $" => Create(Vector0Guards.EnsureNonNegative({conversionExpr}, nameof(value)));"
 				: $" => Create({conversionExpr});";
 
+			// Issue #49: factory names use the plural form. Prefer an explicit FactoryName from
+			// units.json (covers irregular plurals like Foot→Feet, mass nouns like Hertz, and
+			// already-plural compounds like MetersPerSecond). Fall back to "{Name}s" for units
+			// that haven't been migrated yet — wrong for those edge cases but produces a build
+			// rather than a hard failure.
+			string factorySuffix = unitMap.TryGetValue(unitName, out UnitDefinition? unitDef)
+				&& !string.IsNullOrEmpty(unitDef?.FactoryName)
+					? unitDef!.FactoryName
+					: unitName + "s";
+
 			List<string> comments =
 			[
 				"/// <summary>",
@@ -490,7 +500,7 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 			{
 				Comments = comments,
 				Keywords = ["public", "static", fullType],
-				Name = $"From{unitName}",
+				Name = $"From{factorySuffix}",
 				Parameters = [new ParameterTemplate { Type = "T", Name = "value" }],
 				BodyFactory = (b) => b.Write(body),
 			});

--- a/Semantics.SourceGenerators/Metadata/units.json
+++ b/Semantics.SourceGenerators/Metadata/units.json
@@ -8,225 +8,258 @@
           "name": "Meter",
           "symbol": "m",
           "description": "Meter - SI base unit of length.",
-          "system": "SIBase"
+          "system": "SIBase",
+          "factoryName": "Meters"
         },
         {
           "name": "Kilometer",
           "symbol": "km",
           "description": "Kilometer - 1000 meters.",
           "system": "SIDerived",
-          "magnitude": "Kilo"
+          "magnitude": "Kilo",
+          "factoryName": "Kilometers"
         },
         {
           "name": "Centimeter",
           "symbol": "cm",
           "description": "Centimeter - 0.01 meters.",
           "system": "SIDerived",
-          "magnitude": "Centi"
+          "magnitude": "Centi",
+          "factoryName": "Centimeters"
         },
         {
           "name": "Millimeter",
           "symbol": "mm",
           "description": "Millimeter - 0.001 meters.",
           "system": "SIDerived",
-          "magnitude": "Milli"
+          "magnitude": "Milli",
+          "factoryName": "Millimeters"
         },
         {
           "name": "Foot",
           "symbol": "ft",
           "description": "Foot - Imperial unit of length.",
           "system": "Imperial",
-          "conversionFactor": "FeetToMeters"
+          "conversionFactor": "FeetToMeters",
+          "factoryName": "Feet"
         },
         {
           "name": "Inch",
           "symbol": "in",
           "description": "Inch - Imperial unit of length.",
           "system": "Imperial",
-          "conversionFactor": "InchesToMeters"
+          "conversionFactor": "InchesToMeters",
+          "factoryName": "Inches"
         },
         {
           "name": "Micrometer",
           "symbol": "μm",
           "description": "Micrometer - 0.000001 meters.",
           "system": "SIDerived",
-          "magnitude": "Micro"
+          "magnitude": "Micro",
+          "factoryName": "Micrometers"
         },
         {
           "name": "Nanometer",
           "symbol": "nm",
           "description": "Nanometer - 0.000000001 meters.",
           "system": "SIDerived",
-          "magnitude": "Nano"
+          "magnitude": "Nano",
+          "factoryName": "Nanometers"
         },
         {
           "name": "Angstrom",
           "symbol": "Å",
           "description": "Angstrom - 10⁻¹⁰ meters, used for atomic scales.",
           "system": "Other",
-          "conversionFactor": "AngstromToMeters"
+          "conversionFactor": "AngstromToMeters",
+          "factoryName": "Angstroms"
         },
         {
           "name": "Yard",
           "symbol": "yd",
           "description": "Yard - Imperial unit of length.",
           "system": "Imperial",
-          "conversionFactor": "YardToMeters"
+          "conversionFactor": "YardToMeters",
+          "factoryName": "Yards"
         },
         {
           "name": "Mile",
           "symbol": "mi",
           "description": "Mile - Imperial unit of length.",
           "system": "Imperial",
-          "conversionFactor": "MileToMeters"
+          "conversionFactor": "MileToMeters",
+          "factoryName": "Miles"
         },
         {
           "name": "Kilogram",
           "symbol": "kg",
           "description": "Kilogram - SI base unit of mass.",
-          "system": "SIBase"
+          "system": "SIBase",
+          "factoryName": "Kilograms"
         },
         {
           "name": "Gram",
           "symbol": "g",
           "description": "Gram - 0.001 kilograms.",
           "system": "SIDerived",
-          "magnitude": "Milli"
+          "magnitude": "Milli",
+          "factoryName": "Grams"
         },
         {
           "name": "Ton",
           "symbol": "t",
           "description": "Metric ton - 1000 kilograms.",
           "system": "SIDerived",
-          "conversionFactor": "TonToKilograms"
+          "conversionFactor": "TonToKilograms",
+          "factoryName": "Tons"
         },
         {
           "name": "Pound",
           "symbol": "lb",
           "description": "Pound - Imperial unit of mass.",
           "system": "Imperial",
-          "conversionFactor": "PoundToKilograms"
+          "conversionFactor": "PoundToKilograms",
+          "factoryName": "Pounds"
         },
         {
           "name": "Ounce",
           "symbol": "oz",
           "description": "Ounce - Imperial unit of mass.",
           "system": "Imperial",
-          "conversionFactor": "OunceToKilograms"
+          "conversionFactor": "OunceToKilograms",
+          "factoryName": "Ounces"
         },
         {
           "name": "Second",
           "symbol": "s",
           "description": "Second - SI base unit of time.",
-          "system": "SIBase"
+          "system": "SIBase",
+          "factoryName": "Seconds"
         },
         {
           "name": "Minute",
           "symbol": "min",
           "description": "Minute - 60 seconds.",
           "system": "Other",
-          "conversionFactor": "MinuteToSeconds"
+          "conversionFactor": "MinuteToSeconds",
+          "factoryName": "Minutes"
         },
         {
           "name": "Hour",
           "symbol": "h",
           "description": "Hour - 3600 seconds.",
           "system": "Other",
-          "conversionFactor": "HourToSeconds"
+          "conversionFactor": "HourToSeconds",
+          "factoryName": "Hours"
         },
         {
           "name": "Day",
           "symbol": "d",
           "description": "Day - 86400 seconds.",
           "system": "Other",
-          "conversionFactor": "DayToSeconds"
+          "conversionFactor": "DayToSeconds",
+          "factoryName": "Days"
         },
         {
           "name": "Year",
           "symbol": "yr",
           "description": "Year - 365.25 days (31557600 seconds).",
           "system": "Other",
-          "conversionFactor": "YearToSeconds"
+          "conversionFactor": "YearToSeconds",
+          "factoryName": "Years"
         },
         {
           "name": "Millisecond",
           "symbol": "ms",
           "description": "Millisecond - 0.001 seconds.",
           "system": "SIDerived",
-          "magnitude": "Milli"
+          "magnitude": "Milli",
+          "factoryName": "Milliseconds"
         },
         {
           "name": "Microsecond",
           "symbol": "μs",
           "description": "Microsecond - 0.000001 seconds.",
           "system": "SIDerived",
-          "magnitude": "Micro"
+          "magnitude": "Micro",
+          "factoryName": "Microseconds"
         },
         {
           "name": "SquareMeter",
           "symbol": "m²",
           "description": "Square meter - SI derived unit of area.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "SquareMeters"
         },
         {
           "name": "SquareFoot",
           "symbol": "ft²",
           "description": "Square foot - Imperial unit of area.",
           "system": "Imperial",
-          "conversionFactor": "SquareFootToSquareMeters"
+          "conversionFactor": "SquareFootToSquareMeters",
+          "factoryName": "SquareFeet"
         },
         {
           "name": "SquareInch",
           "symbol": "in²",
           "description": "Square inch - Imperial unit of area.",
           "system": "Imperial",
-          "conversionFactor": "SquareInchToSquareMeters"
+          "conversionFactor": "SquareInchToSquareMeters",
+          "factoryName": "SquareInches"
         },
         {
           "name": "CubicMeter",
           "symbol": "m³",
           "description": "Cubic meter - SI derived unit of volume.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "CubicMeters"
         },
         {
           "name": "Liter",
           "symbol": "L",
           "description": "Liter - 0.001 cubic meters.",
           "system": "SIDerived",
-          "conversionFactor": "LiterToCubicMeters"
+          "conversionFactor": "LiterToCubicMeters",
+          "factoryName": "Liters"
         },
         {
           "name": "Milliliter",
           "symbol": "mL",
           "description": "Milliliter - 0.001 liters.",
           "system": "SIDerived",
-          "magnitude": "Milli"
+          "magnitude": "Milli",
+          "factoryName": "Milliliters"
         },
         {
           "name": "Gallon",
           "symbol": "gal",
           "description": "US gallon - Imperial unit of volume.",
           "system": "Imperial",
-          "conversionFactor": "GallonToCubicMeters"
+          "conversionFactor": "GallonToCubicMeters",
+          "factoryName": "Gallons"
         },
         {
           "name": "Dimensionless",
           "symbol": "1",
           "description": "Dimensionless - Pure number or ratio with no physical units.",
-          "system": "SIBase"
+          "system": "SIBase",
+          "factoryName": "Dimensionless"
         },
         {
           "name": "Radian",
           "symbol": "rad",
           "description": "Radian - SI derived unit of plane angle.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Radians"
         },
         {
           "name": "Degree",
           "symbol": "°",
           "description": "Degree - Common unit of plane angle.",
           "system": "Other",
-          "conversionFactor": "DegreeToRadians"
+          "conversionFactor": "DegreeToRadians",
+          "factoryName": "Degrees"
         }
       ]
     },
@@ -238,143 +271,165 @@
           "name": "Newton",
           "symbol": "N",
           "description": "Newton - SI derived unit of force.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Newtons"
         },
         {
           "name": "Pascal",
           "symbol": "Pa",
           "description": "Pascal - SI derived unit of pressure.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Pascals"
         },
         {
           "name": "MetersPerSecond",
           "symbol": "m/s",
           "description": "Meters per second - SI derived unit of velocity.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "MetersPerSecond"
         },
         {
           "name": "MetersPerSecondSquared",
           "symbol": "m/s²",
           "description": "Meters per second squared - SI derived unit of acceleration.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "MetersPerSecondSquared"
         },
         {
           "name": "Bar",
           "symbol": "bar",
           "description": "Bar - Metric unit of pressure.",
           "system": "SIDerived",
-          "conversionFactor": "BarToPascals"
+          "conversionFactor": "BarToPascals",
+          "factoryName": "Bars"
         },
         {
           "name": "Atmosphere",
           "symbol": "atm",
           "description": "Standard atmosphere - Unit of pressure.",
           "system": "Other",
-          "conversionFactor": "AtmosphereToPascals"
+          "conversionFactor": "AtmosphereToPascals",
+          "factoryName": "Atmospheres"
         },
         {
           "name": "Psi",
           "symbol": "psi",
           "description": "Pounds per square inch - Imperial unit of pressure.",
           "system": "Imperial",
-          "conversionFactor": "PsiToPascals"
+          "conversionFactor": "PsiToPascals",
+          "factoryName": "Psi"
         },
         {
           "name": "KilometersPerHour",
           "symbol": "km/h",
           "description": "Kilometers per hour - Common unit of velocity.",
           "system": "SIDerived",
-          "conversionFactor": "KilometersPerHourToMetersPerSecond"
+          "conversionFactor": "KilometersPerHourToMetersPerSecond",
+          "factoryName": "KilometersPerHour"
         },
         {
           "name": "MilesPerHour",
           "symbol": "mph",
           "description": "Miles per hour - Imperial unit of velocity.",
           "system": "Imperial",
-          "conversionFactor": "MilesPerHourToMetersPerSecond"
+          "conversionFactor": "MilesPerHourToMetersPerSecond",
+          "factoryName": "MilesPerHour"
         },
         {
           "name": "Joule",
           "symbol": "J",
           "description": "Joule - SI derived unit of energy.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Joules"
         },
         {
           "name": "Watt",
           "symbol": "W",
           "description": "Watt - SI derived unit of power.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Watts"
         },
         {
           "name": "Calorie",
           "symbol": "cal",
           "description": "Calorie - Thermochemical calorie, energy unit.",
           "system": "Other",
-          "conversionFactor": "CalorieToJoules"
+          "conversionFactor": "CalorieToJoules",
+          "factoryName": "Calories"
         },
         {
           "name": "KilowattHour",
           "symbol": "kWh",
           "description": "Kilowatt-hour - Common unit of electrical energy.",
           "system": "SIDerived",
-          "conversionFactor": "KilowattHourToJoules"
+          "conversionFactor": "KilowattHourToJoules",
+          "factoryName": "KilowattHours"
         },
         {
           "name": "Horsepower",
           "symbol": "hp",
           "description": "Mechanical horsepower - Imperial unit of power.",
           "system": "Imperial",
-          "conversionFactor": "HorsepowerToWatts"
+          "conversionFactor": "HorsepowerToWatts",
+          "factoryName": "Horsepower"
         },
         {
           "name": "NewtonSecond",
           "symbol": "N⋅s",
           "description": "Newton-second - SI derived unit of momentum.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "NewtonSeconds"
         },
         {
           "name": "ElectronVolt",
           "symbol": "eV",
           "description": "Electron volt - Energy unit equal to electron charge times one volt.",
           "system": "Other",
-          "conversionFactor": "ElectronVoltToJoules"
+          "conversionFactor": "ElectronVoltToJoules",
+          "factoryName": "ElectronVolts"
         },
         {
           "name": "NewtonMeter",
           "symbol": "N⋅m",
           "description": "Newton-meter - SI derived unit of torque.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "NewtonMeters"
         },
         {
           "name": "PoundFoot",
           "symbol": "lb⋅ft",
           "description": "Pound-foot - Imperial unit of torque.",
           "system": "Imperial",
-          "conversionFactor": "PoundFootToNewtonMeters"
+          "conversionFactor": "PoundFootToNewtonMeters",
+          "factoryName": "PoundFeet"
         },
         {
           "name": "KilogramMeterSquared",
           "symbol": "kg⋅m²",
           "description": "Kilogram-meter squared - SI derived unit of moment of inertia.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "KilogramMeterSquared"
         },
         {
           "name": "KilogramMeterSquaredPerSecond",
           "symbol": "kg⋅m²/s",
           "description": "Kilogram-meter squared per second - SI derived unit of angular momentum.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "KilogramMeterSquaredPerSecond"
         },
         {
           "name": "MetersPerSecondCubed",
           "symbol": "m/s³",
           "description": "Meters per second cubed - SI derived unit of jerk.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "MetersPerSecondCubed"
         },
         {
           "name": "MetersPerSecondQuartic",
           "symbol": "m/s⁴",
           "description": "Meters per second to the fourth - SI derived unit of snap.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "MetersPerSecondQuartic"
         }
       ]
     },
@@ -386,14 +441,16 @@
           "name": "Kelvin",
           "symbol": "K",
           "description": "Kelvin - SI base unit of thermodynamic temperature.",
-          "system": "SIBase"
+          "system": "SIBase",
+          "factoryName": "Kelvins"
         },
         {
           "name": "Celsius",
           "symbol": "°C",
           "description": "Celsius - Common temperature scale.",
           "system": "SIDerived",
-          "offset": "CelsiusToKelvinOffset"
+          "offset": "CelsiusToKelvinOffset",
+          "factoryName": "Celsius"
         },
         {
           "name": "Fahrenheit",
@@ -401,37 +458,43 @@
           "description": "Fahrenheit - Imperial temperature scale.",
           "system": "Imperial",
           "conversionFactor": "FahrenheitScale",
-          "offset": "FahrenheitToKelvinOffset"
+          "offset": "FahrenheitToKelvinOffset",
+          "factoryName": "Fahrenheit"
         },
         {
           "name": "JoulePerKelvin",
           "symbol": "J/K",
           "description": "Joule per kelvin - SI derived unit of entropy and heat capacity.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "JoulePerKelvin"
         },
         {
           "name": "JoulePerKilogramKelvin",
           "symbol": "J/(kg·K)",
           "description": "Joule per kilogram kelvin - SI derived unit of specific heat capacity.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "JoulePerKilogramKelvin"
         },
         {
           "name": "WattPerMeterKelvin",
           "symbol": "W/(m·K)",
           "description": "Watt per meter kelvin - SI derived unit of thermal conductivity.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "WattPerMeterKelvin"
         },
         {
           "name": "WattPerSquareMeterKelvin",
           "symbol": "W/(m²·K)",
           "description": "Watt per square meter kelvin - SI derived unit of heat transfer coefficient.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "WattPerSquareMeterKelvin"
         },
         {
           "name": "PerKelvin",
           "symbol": "K⁻¹",
           "description": "Per kelvin - SI derived unit of thermal expansion coefficient.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "PerKelvin"
         }
       ]
     },
@@ -443,68 +506,79 @@
           "name": "Ampere",
           "symbol": "A",
           "description": "Ampere - SI base unit of electric current.",
-          "system": "SIBase"
+          "system": "SIBase",
+          "factoryName": "Amperes"
         },
         {
           "name": "Volt",
           "symbol": "V",
           "description": "Volt - SI derived unit of electric potential.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Volts"
         },
         {
           "name": "VoltPerMeter",
           "symbol": "V/m",
           "description": "Volt per meter - SI derived unit of electric field strength.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "VoltPerMeter"
         },
         {
           "name": "Ohm",
           "symbol": "Ω",
           "description": "Ohm - SI derived unit of electric resistance.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Ohms"
         },
         {
           "name": "Coulomb",
           "symbol": "C",
           "description": "Coulomb - SI derived unit of electric charge.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Coulombs"
         },
         {
           "name": "Farad",
           "symbol": "F",
           "description": "Farad - SI derived unit of electric capacitance.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Farads"
         },
         {
           "name": "Siemens",
           "symbol": "S",
           "description": "Siemens - SI derived unit of electric conductance.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Siemens"
         },
         {
           "name": "Tesla",
           "symbol": "T",
           "description": "Tesla - SI derived unit of magnetic flux density.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Teslas"
         },
         {
           "name": "Gauss",
           "symbol": "G",
           "description": "Gauss - CGS unit of magnetic flux density.",
           "system": "CGS",
-          "conversionFactor": "GaussToTesla"
+          "conversionFactor": "GaussToTesla",
+          "factoryName": "Gauss"
         },
         {
           "name": "Weber",
           "symbol": "Wb",
           "description": "Weber - SI derived unit of magnetic flux.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Webers"
         },
         {
           "name": "Henry",
           "symbol": "H",
           "description": "Henry - SI derived unit of inductance.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Henries"
         }
       ]
     },
@@ -516,26 +590,30 @@
           "name": "RadiansPerSecond",
           "symbol": "rad/s",
           "description": "Radians per second - SI derived unit of angular velocity.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "RadiansPerSecond"
         },
         {
           "name": "RevolutionsPerMinute",
           "symbol": "rpm",
           "description": "Revolutions per minute - Common unit of angular velocity.",
           "system": "Other",
-          "conversionFactor": "RevolutionsPerMinuteToRadiansPerSecond"
+          "conversionFactor": "RevolutionsPerMinuteToRadiansPerSecond",
+          "factoryName": "RevolutionsPerMinute"
         },
         {
           "name": "RadiansPerSecondSquared",
           "symbol": "rad/s²",
           "description": "Radians per second squared - SI derived unit of angular acceleration.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "RadiansPerSecondSquared"
         },
         {
           "name": "RadiansPerSecondCubed",
           "symbol": "rad/s³",
           "description": "Radians per second cubed - SI derived unit of angular jerk.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "RadiansPerSecondCubed"
         }
       ]
     },
@@ -547,7 +625,8 @@
           "name": "Hertz",
           "symbol": "Hz",
           "description": "Hertz - SI derived unit of frequency.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Hertz"
         }
       ]
     },
@@ -559,25 +638,29 @@
           "name": "Candela",
           "symbol": "cd",
           "description": "Candela - SI base unit of luminous intensity.",
-          "system": "SIBase"
+          "system": "SIBase",
+          "factoryName": "Candelas"
         },
         {
           "name": "Lumen",
           "symbol": "lm",
           "description": "Lumen - SI derived unit of luminous flux.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Lumens"
         },
         {
           "name": "Lux",
           "symbol": "lx",
           "description": "Lux - SI derived unit of illuminance.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Lux"
         },
         {
           "name": "Diopter",
           "symbol": "D",
           "description": "Diopter - SI unit of optical power.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Diopters"
         }
       ]
     },
@@ -589,32 +672,37 @@
           "name": "Becquerel",
           "symbol": "Bq",
           "description": "Becquerel - SI derived unit of radioactive activity.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Becquerels"
         },
         {
           "name": "Gray",
           "symbol": "Gy",
           "description": "Gray - SI derived unit of absorbed dose.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Grays"
         },
         {
           "name": "Sievert",
           "symbol": "Sv",
           "description": "Sievert - SI derived unit of equivalent dose.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Sieverts"
         },
         {
           "name": "Barn",
           "symbol": "b",
           "description": "Barn - Unit of nuclear cross section.",
           "system": "Other",
-          "conversionFactor": "BarnToSquareMeters"
+          "conversionFactor": "BarnToSquareMeters",
+          "factoryName": "Barns"
         },
         {
           "name": "CoulombPerKilogram",
           "symbol": "C/kg",
           "description": "Coulomb per kilogram - SI derived unit of radiation exposure.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "CoulombPerKilogram"
         }
       ]
     },
@@ -626,7 +714,8 @@
           "name": "KilogramPerCubicMeter",
           "symbol": "kg/m³",
           "description": "Kilogram per cubic meter - SI derived unit of density.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "KilogramPerCubicMeter"
         }
       ]
     },
@@ -638,14 +727,16 @@
           "name": "Mole",
           "symbol": "mol",
           "description": "Mole - SI base unit of amount of substance.",
-          "system": "SIBase"
+          "system": "SIBase",
+          "factoryName": "Moles"
         },
         {
           "name": "Molar",
           "symbol": "M",
           "description": "Molar - Moles per liter concentration.",
           "system": "SIDerived",
-          "conversionFactor": "MolarToCubicMeter"
+          "conversionFactor": "MolarToCubicMeter",
+          "factoryName": "Molars"
         }
       ]
     },
@@ -657,52 +748,60 @@
           "name": "SquareMeterPerSecond",
           "symbol": "m²/s",
           "description": "Square meter per second - SI derived unit of kinematic viscosity.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "SquareMeterPerSecond"
         },
         {
           "name": "Stokes",
           "symbol": "St",
           "description": "Stokes - CGS unit of kinematic viscosity.",
           "system": "CGS",
-          "conversionFactor": "StokesToSquareMeterPerSecond"
+          "conversionFactor": "StokesToSquareMeterPerSecond",
+          "factoryName": "Stokes"
         },
         {
           "name": "PascalSecond",
           "symbol": "Pa·s",
           "description": "Pascal second - SI derived unit of dynamic viscosity.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "PascalSeconds"
         },
         {
           "name": "Poise",
           "symbol": "P",
           "description": "Poise - CGS unit of dynamic viscosity.",
           "system": "CGS",
-          "conversionFactor": "PoiseToPascalSecond"
+          "conversionFactor": "PoiseToPascalSecond",
+          "factoryName": "Poise"
         },
         {
           "name": "CubicMeterPerSecond",
           "symbol": "m³/s",
           "description": "Cubic meter per second - SI derived unit of volumetric flow rate.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "CubicMeterPerSecond"
         },
         {
           "name": "LiterPerSecond",
           "symbol": "L/s",
           "description": "Liter per second - Common unit of volumetric flow rate.",
           "system": "SIDerived",
-          "conversionFactor": "LiterPerSecondToCubicMeterPerSecond"
+          "conversionFactor": "LiterPerSecondToCubicMeterPerSecond",
+          "factoryName": "LiterPerSecond"
         },
         {
           "name": "KilogramPerSecond",
           "symbol": "kg/s",
           "description": "Kilogram per second - SI derived unit of mass flow rate.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "KilogramPerSecond"
         },
         {
           "name": "NewtonPerMeter",
           "symbol": "N/m",
           "description": "Newton per meter - SI derived unit of surface tension.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "NewtonPerMeter"
         }
       ]
     },
@@ -714,39 +813,45 @@
           "name": "KilogramPerMole",
           "symbol": "kg/mol",
           "description": "Kilogram per mole - SI derived unit of molar mass.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "KilogramPerMole"
         },
         {
           "name": "GramPerMole",
           "symbol": "g/mol",
           "description": "Gram per mole - Common unit of molar mass.",
           "system": "SIDerived",
-          "conversionFactor": "GramPerMoleToKilogramPerMole"
+          "conversionFactor": "GramPerMoleToKilogramPerMole",
+          "factoryName": "GramPerMole"
         },
         {
           "name": "Katal",
           "symbol": "kat",
           "description": "Katal - SI derived unit of catalytic activity.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "Katals"
         },
         {
           "name": "MolePerCubicMeterSecond",
           "symbol": "mol/(m³·s)",
           "description": "Mole per cubic meter second - SI derived unit of reaction rate.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "MolePerCubicMeterSecond"
         },
         {
           "name": "JoulePerMole",
           "symbol": "J/mol",
           "description": "Joule per mole - SI derived unit of molar energy.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "JoulePerMole"
         },
         {
           "name": "KilojoulePerMole",
           "symbol": "kJ/mol",
           "description": "Kilojoule per mole - Common unit of molar energy.",
           "system": "SIDerived",
-          "conversionFactor": "KilojoulePerMoleToJoulePerMole"
+          "conversionFactor": "KilojoulePerMoleToJoulePerMole",
+          "factoryName": "KilojoulePerMole"
         }
       ]
     },
@@ -758,13 +863,15 @@
           "name": "WattPerSquareMeter",
           "symbol": "W/m²",
           "description": "Watt per square meter - SI derived unit of irradiance and sound intensity.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "WattPerSquareMeter"
         },
         {
           "name": "PascalSecondPerMeter",
           "symbol": "Pa·s/m",
           "description": "Pascal second per meter - SI derived unit of acoustic impedance.",
-          "system": "SIDerived"
+          "system": "SIDerived",
+          "factoryName": "PascalSecondPerMeter"
         }
       ]
     }

--- a/Semantics.SourceGenerators/Models/UnitsMetadata.cs
+++ b/Semantics.SourceGenerators/Models/UnitsMetadata.cs
@@ -27,4 +27,13 @@ public class UnitDefinition
 	public string Magnitude { get; set; } = "1";
 	public string ConversionFactor { get; set; } = "1";
 	public string Offset { get; set; } = "0";
+
+	/// <summary>
+	/// Plural-form identifier used when emitting <c>From{FactoryName}</c> factories per #49.
+	/// Empty string means "fall back to the rule built into the generator" — currently
+	/// <c>Name + "s"</c>, which is correct for regular units (Meter→Meters, Newton→Newtons)
+	/// but wrong for irregulars (Foot, Inch), already-plural compounds (MetersPerSecond),
+	/// and mass nouns (Hertz, Lux, Siemens). Set this explicitly for those cases.
+	/// </summary>
+	public string FactoryName { get; set; } = string.Empty;
 }

--- a/Semantics.Test/Quantities/MultiUnitFactoryTests.cs
+++ b/Semantics.Test/Quantities/MultiUnitFactoryTests.cs
@@ -20,129 +20,129 @@ public sealed class MultiUnitFactoryTests
 	// ---- Length ----
 
 	[TestMethod]
-	public void Length_FromMeter_Identity()
+	public void Length_FromMeters_Identity()
 	{
-		Length<double> l = Length<double>.FromMeter(1.0);
+		Length<double> l = Length<double>.FromMeters(1.0);
 		Assert.AreEqual(1.0, l.Value, Tolerance);
 	}
 
 	[TestMethod]
-	public void Length_FromKilometer_Scales_By_1000()
+	public void Length_FromKilometers_Scales_By_1000()
 	{
-		Length<double> l = Length<double>.FromKilometer(1.0);
+		Length<double> l = Length<double>.FromKilometers(1.0);
 		Assert.AreEqual(1000.0, l.Value, Tolerance);
 	}
 
 	[TestMethod]
-	public void Length_FromCentimeter_Scales_By_0_01()
+	public void Length_FromCentimeters_Scales_By_0_01()
 	{
-		Length<double> l = Length<double>.FromCentimeter(1.0);
+		Length<double> l = Length<double>.FromCentimeters(1.0);
 		Assert.AreEqual(0.01, l.Value, Tolerance);
 	}
 
 	[TestMethod]
-	public void Length_FromMillimeter_Scales_By_0_001()
+	public void Length_FromMillimeters_Scales_By_0_001()
 	{
-		Length<double> l = Length<double>.FromMillimeter(1.0);
+		Length<double> l = Length<double>.FromMillimeters(1.0);
 		Assert.AreEqual(0.001, l.Value, Tolerance);
 	}
 
 	[TestMethod]
-	public void Length_FromFoot_Uses_FeetToMeters_Constant()
+	public void Length_FromFeet_Uses_FeetToMeters_Constant()
 	{
-		Length<double> l = Length<double>.FromFoot(1.0);
+		Length<double> l = Length<double>.FromFeet(1.0);
 		Assert.AreEqual(0.3048, l.Value, Tolerance);
 	}
 
 	[TestMethod]
-	public void Length_FromInch_Uses_InchesToMeters_Constant()
+	public void Length_FromInches_Uses_InchesToMeters_Constant()
 	{
-		Length<double> l = Length<double>.FromInch(1.0);
+		Length<double> l = Length<double>.FromInches(1.0);
 		Assert.AreEqual(0.0254, l.Value, Tolerance);
 	}
 
 	[TestMethod]
-	public void Length_FromMile_Uses_MileToMeters_Constant()
+	public void Length_FromMiles_Uses_MileToMeters_Constant()
 	{
-		Length<double> l = Length<double>.FromMile(1.0);
+		Length<double> l = Length<double>.FromMiles(1.0);
 		Assert.AreEqual(1609.344, l.Value, Tolerance);
 	}
 
 	// ---- Mass ----
 
 	[TestMethod]
-	public void Mass_FromKilogram_Identity()
+	public void Mass_FromKilograms_Identity()
 	{
-		Mass<double> m = Mass<double>.FromKilogram(1.0);
+		Mass<double> m = Mass<double>.FromKilograms(1.0);
 		Assert.AreEqual(1.0, m.Value, Tolerance);
 	}
 
 	[TestMethod]
-	public void Mass_FromGram_Scales_By_0_001()
+	public void Mass_FromGrams_Scales_By_0_001()
 	{
-		Mass<double> m = Mass<double>.FromGram(1.0);
+		Mass<double> m = Mass<double>.FromGrams(1.0);
 		Assert.AreEqual(0.001, m.Value, Tolerance);
 	}
 
 	[TestMethod]
-	public void Mass_FromPound_Uses_PoundToKilograms_Constant()
+	public void Mass_FromPounds_Uses_PoundToKilograms_Constant()
 	{
-		Mass<double> m = Mass<double>.FromPound(1.0);
+		Mass<double> m = Mass<double>.FromPounds(1.0);
 		Assert.AreEqual(0.45359237, m.Value, Tolerance);
 	}
 
 	// ---- Time / Duration ----
 
 	[TestMethod]
-	public void Duration_FromMinute_Equals_60_Seconds()
+	public void Duration_FromMinutes_Equals_60_Seconds()
 	{
-		Duration<double> d = Duration<double>.FromMinute(1.0);
+		Duration<double> d = Duration<double>.FromMinutes(1.0);
 		Assert.AreEqual(60.0, d.Value, Tolerance);
 	}
 
 	[TestMethod]
-	public void Duration_FromHour_Equals_3600_Seconds()
+	public void Duration_FromHours_Equals_3600_Seconds()
 	{
-		Duration<double> d = Duration<double>.FromHour(1.0);
+		Duration<double> d = Duration<double>.FromHours(1.0);
 		Assert.AreEqual(3600.0, d.Value, Tolerance);
 	}
 
 	// ---- Semantic overloads inherit their dimension's full unit set ----
 
 	[TestMethod]
-	public void Distance_FromKilometer_Scales_By_1000()
+	public void Distance_FromKilometers_Scales_By_1000()
 	{
-		Distance<double> d = Distance<double>.FromKilometer(1.0);
+		Distance<double> d = Distance<double>.FromKilometers(1.0);
 		Assert.AreEqual(1000.0, d.Value, Tolerance);
 	}
 
 	[TestMethod]
-	public void Diameter_FromMillimeter_Scales_By_0_001()
+	public void Diameter_FromMillimeters_Scales_By_0_001()
 	{
-		Diameter<double> d = Diameter<double>.FromMillimeter(1.0);
+		Diameter<double> d = Diameter<double>.FromMillimeters(1.0);
 		Assert.AreEqual(0.001, d.Value, Tolerance);
 	}
 
 	[TestMethod]
-	public void Wavelength_FromNanometer_Uses_Nano_Magnitude()
+	public void Wavelength_FromNanometers_Uses_Nano_Magnitude()
 	{
-		Wavelength<double> w = Wavelength<double>.FromNanometer(550.0);
+		Wavelength<double> w = Wavelength<double>.FromNanometers(550.0);
 		Assert.AreEqual(550.0e-9, w.Value, 1e-15);
 	}
 
 	// ---- Storage genericity ----
 
 	[TestMethod]
-	public void Length_FromKilometer_Works_With_Float()
+	public void Length_FromKilometers_Works_With_Float()
 	{
-		Length<float> l = Length<float>.FromKilometer(1.0f);
+		Length<float> l = Length<float>.FromKilometers(1.0f);
 		Assert.AreEqual(1000.0f, l.Value, 1e-3f);
 	}
 
 	[TestMethod]
-	public void Length_FromFoot_Works_With_Decimal()
+	public void Length_FromFeet_Works_With_Decimal()
 	{
-		Length<decimal> l = Length<decimal>.FromFoot(1m);
+		Length<decimal> l = Length<decimal>.FromFeet(1m);
 		Assert.AreEqual(0.3048m, l.Value);
 	}
 }

--- a/Semantics.Test/Quantities/SemanticOverloadTests.cs
+++ b/Semantics.Test/Quantities/SemanticOverloadTests.cs
@@ -21,7 +21,7 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void Weight_Widens_Implicitly_To_ForceMagnitude()
 	{
-		Weight<double> w = Weight<double>.FromNewton(686.0);
+		Weight<double> w = Weight<double>.FromNewtons(686.0);
 		ForceMagnitude<double> baseValue = w; // implicit conversion
 		Assert.AreEqual(686.0, baseValue.Value, Tolerance);
 	}
@@ -29,7 +29,7 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void Distance_Widens_Implicitly_To_Length()
 	{
-		Distance<double> d = Distance<double>.FromMeter(42.0);
+		Distance<double> d = Distance<double>.FromMeters(42.0);
 		Length<double> len = d;
 		Assert.AreEqual(42.0, len.Value, Tolerance);
 	}
@@ -37,7 +37,7 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void Diameter_Widens_Implicitly_To_Length()
 	{
-		Diameter<double> diam = Diameter<double>.FromMeter(10.0);
+		Diameter<double> diam = Diameter<double>.FromMeters(10.0);
 		Length<double> len = diam;
 		Assert.AreEqual(10.0, len.Value, Tolerance);
 	}
@@ -47,7 +47,7 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void ForceMagnitude_Narrows_Explicitly_To_Weight()
 	{
-		ForceMagnitude<double> fm = ForceMagnitude<double>.FromNewton(686.0);
+		ForceMagnitude<double> fm = ForceMagnitude<double>.FromNewtons(686.0);
 		Weight<double> w = (Weight<double>)fm;
 		Assert.AreEqual(686.0, w.Value, Tolerance);
 	}
@@ -55,7 +55,7 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void Length_Narrows_Explicitly_To_Distance()
 	{
-		Length<double> len = Length<double>.FromMeter(42.0);
+		Length<double> len = Length<double>.FromMeters(42.0);
 		Distance<double> d = (Distance<double>)len;
 		Assert.AreEqual(42.0, d.Value, Tolerance);
 	}
@@ -65,7 +65,7 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void Weight_From_ForceMagnitude_Constructs()
 	{
-		ForceMagnitude<double> fm = ForceMagnitude<double>.FromNewton(100.0);
+		ForceMagnitude<double> fm = ForceMagnitude<double>.FromNewtons(100.0);
 		Weight<double> w = Weight<double>.From(fm);
 		Assert.AreEqual(100.0, w.Value, Tolerance);
 	}
@@ -73,7 +73,7 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void Distance_From_Length_Constructs()
 	{
-		Length<double> len = Length<double>.FromMeter(7.0);
+		Length<double> len = Length<double>.FromMeters(7.0);
 		Distance<double> d = Distance<double>.From(len);
 		Assert.AreEqual(7.0, d.Value, Tolerance);
 	}
@@ -83,7 +83,7 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void Weight_RoundTrip_Through_ForceMagnitude_Preserves_Value()
 	{
-		Weight<double> original = Weight<double>.FromNewton(123.456);
+		Weight<double> original = Weight<double>.FromNewtons(123.456);
 		ForceMagnitude<double> widened = original;
 		Weight<double> narrowed = (Weight<double>)widened;
 		Assert.AreEqual(original.Value, narrowed.Value, Tolerance);
@@ -94,7 +94,7 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void Diameter_ToRadius_Halves_Value()
 	{
-		Diameter<double> d = Diameter<double>.FromMeter(10.0);
+		Diameter<double> d = Diameter<double>.FromMeters(10.0);
 		Radius<double> r = d.ToRadius();
 		Assert.AreEqual(5.0, r.Value, Tolerance);
 	}
@@ -102,7 +102,7 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void Diameter_FromRadius_Doubles_Value()
 	{
-		Radius<double> r = Radius<double>.FromMeter(5.0);
+		Radius<double> r = Radius<double>.FromMeters(5.0);
 		Diameter<double> d = Diameter<double>.FromRadius(r);
 		Assert.AreEqual(10.0, d.Value, Tolerance);
 	}
@@ -110,7 +110,7 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void Diameter_RoundTrip_Through_Radius_Preserves_Value()
 	{
-		Diameter<double> d = Diameter<double>.FromMeter(20.0);
+		Diameter<double> d = Diameter<double>.FromMeters(20.0);
 		Radius<double> r = d.ToRadius();
 		Diameter<double> back = Diameter<double>.FromRadius(r);
 		Assert.AreEqual(d.Value, back.Value, Tolerance);
@@ -125,8 +125,8 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void Weight_Minus_Weight_Currently_Returns_Force1D_PendingFix52()
 	{
-		Weight<double> a = Weight<double>.FromNewton(100.0);
-		Weight<double> b = Weight<double>.FromNewton(150.0);
+		Weight<double> a = Weight<double>.FromNewtons(100.0);
+		Weight<double> b = Weight<double>.FromNewtons(150.0);
 		Force1D<double> diff = a - b; // current generator behaviour; #52 plans Weight of |a - b|.
 		Assert.AreEqual(-50.0, diff.Value, Tolerance);
 	}
@@ -136,7 +136,7 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void Diameter_ToRadius_Works_With_Float_Storage()
 	{
-		Diameter<float> d = Diameter<float>.FromMeter(10.0f);
+		Diameter<float> d = Diameter<float>.FromMeters(10.0f);
 		Radius<float> r = d.ToRadius();
 		Assert.AreEqual(5.0f, r.Value, 1e-6f);
 	}
@@ -144,7 +144,7 @@ public sealed class SemanticOverloadTests
 	[TestMethod]
 	public void Diameter_ToRadius_Works_With_Decimal_Storage()
 	{
-		Diameter<decimal> d = Diameter<decimal>.FromMeter(10m);
+		Diameter<decimal> d = Diameter<decimal>.FromMeters(10m);
 		Radius<decimal> r = d.ToRadius();
 		Assert.AreEqual(5m, r.Value);
 	}

--- a/Semantics.Test/Quantities/Vector0InvariantTests.cs
+++ b/Semantics.Test/Quantities/Vector0InvariantTests.cs
@@ -27,16 +27,16 @@ public sealed class Vector0InvariantTests
 		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Speed<double>.FromMetersPerSecond(-1.0));
 
 	[TestMethod]
-	public void Mass_FromKilogram_Negative_Throws()
-		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Mass<double>.FromKilogram(-0.5));
+	public void Mass_FromKilograms_Negative_Throws()
+		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Mass<double>.FromKilograms(-0.5));
 
 	[TestMethod]
-	public void Length_FromMeter_Negative_Throws()
-		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Length<double>.FromMeter(-3.0));
+	public void Length_FromMeters_Negative_Throws()
+		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Length<double>.FromMeters(-3.0));
 
 	[TestMethod]
-	public void Energy_FromJoule_Negative_Throws()
-		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Energy<double>.FromJoule(-100.0));
+	public void Energy_FromJoules_Negative_Throws()
+		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Energy<double>.FromJoules(-100.0));
 
 	[TestMethod]
 	public void Speed_FromMetersPerSecond_Zero_Allowed()
@@ -46,21 +46,21 @@ public sealed class Vector0InvariantTests
 	}
 
 	[TestMethod]
-	public void Mass_FromKilogram_Positive_Returns_Same_Value()
+	public void Mass_FromKilograms_Positive_Returns_Same_Value()
 	{
-		Mass<double> m = Mass<double>.FromKilogram(2.5);
+		Mass<double> m = Mass<double>.FromKilograms(2.5);
 		Assert.AreEqual(2.5, m.Value, Tolerance);
 	}
 
 	// V0 overloads inherit non-negativity from their dimension.
 
 	[TestMethod]
-	public void Distance_FromMeter_Negative_Throws()
-		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Distance<double>.FromMeter(-1.0));
+	public void Distance_FromMeters_Negative_Throws()
+		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Distance<double>.FromMeters(-1.0));
 
 	[TestMethod]
-	public void Weight_FromNewton_Negative_Throws()
-		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Weight<double>.FromNewton(-9.81));
+	public void Weight_FromNewtons_Negative_Throws()
+		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Weight<double>.FromNewtons(-9.81));
 
 	// V1 quantities are signed and accept any input.
 
@@ -72,29 +72,29 @@ public sealed class Vector0InvariantTests
 	}
 
 	[TestMethod]
-	public void TemperatureDelta_FromKelvin_Negative_Allowed()
+	public void TemperatureDelta_FromKelvins_Negative_Allowed()
 	{
-		TemperatureDelta<double> dt = TemperatureDelta<double>.FromKelvin(-10.0);
+		TemperatureDelta<double> dt = TemperatureDelta<double>.FromKelvins(-10.0);
 		Assert.AreEqual(-10.0, dt.Value, Tolerance);
 	}
 
 	// Storage-type genericity for the guard.
 
 	[TestMethod]
-	public void Mass_FromKilogram_Negative_Throws_With_Float()
-		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Mass<float>.FromKilogram(-1.0f));
+	public void Mass_FromKilograms_Negative_Throws_With_Float()
+		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Mass<float>.FromKilograms(-1.0f));
 
 	[TestMethod]
-	public void Mass_FromKilogram_Negative_Throws_With_Decimal()
-		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Mass<decimal>.FromKilogram(-1m));
+	public void Mass_FromKilograms_Negative_Throws_With_Decimal()
+		=> _ = Assert.ThrowsExactly<ArgumentException>(() => Mass<decimal>.FromKilograms(-1m));
 
 	// =========================================================== #52: Absolute subtraction
 
 	[TestMethod]
 	public void Mass_Minus_Larger_Mass_Returns_Mass_Of_Absolute_Difference()
 	{
-		Mass<double> small = Mass<double>.FromKilogram(3.0);
-		Mass<double> large = Mass<double>.FromKilogram(5.0);
+		Mass<double> small = Mass<double>.FromKilograms(3.0);
+		Mass<double> large = Mass<double>.FromKilograms(5.0);
 		Mass<double> diff = small - large;
 		Assert.AreEqual(2.0, diff.Value, Tolerance);
 		Assert.IsInstanceOfType<Mass<double>>(diff);
@@ -103,8 +103,8 @@ public sealed class Vector0InvariantTests
 	[TestMethod]
 	public void Mass_Minus_Smaller_Mass_Returns_Positive_Mass()
 	{
-		Mass<double> large = Mass<double>.FromKilogram(5.0);
-		Mass<double> small = Mass<double>.FromKilogram(3.0);
+		Mass<double> large = Mass<double>.FromKilograms(5.0);
+		Mass<double> small = Mass<double>.FromKilograms(3.0);
 		Mass<double> diff = large - small;
 		Assert.AreEqual(2.0, diff.Value, Tolerance);
 	}
@@ -121,8 +121,8 @@ public sealed class Vector0InvariantTests
 	[TestMethod]
 	public void Length_Minus_Length_Returns_Length()
 	{
-		Length<double> a = Length<double>.FromMeter(7.0);
-		Length<double> b = Length<double>.FromMeter(2.0);
+		Length<double> a = Length<double>.FromMeters(7.0);
+		Length<double> b = Length<double>.FromMeters(2.0);
 		Length<double> diff = a - b;
 		Assert.AreEqual(5.0, diff.Value, Tolerance);
 	}
@@ -132,8 +132,8 @@ public sealed class Vector0InvariantTests
 	[TestMethod]
 	public void Weight_Minus_Weight_Stays_Weight_With_Absolute_Difference()
 	{
-		Weight<double> a = Weight<double>.FromNewton(100.0);
-		Weight<double> b = Weight<double>.FromNewton(150.0);
+		Weight<double> a = Weight<double>.FromNewtons(100.0);
+		Weight<double> b = Weight<double>.FromNewtons(150.0);
 		Weight<double> diff = a - b;
 		Assert.AreEqual(50.0, diff.Value, Tolerance);
 		Assert.IsInstanceOfType<Weight<double>>(diff);
@@ -142,8 +142,8 @@ public sealed class Vector0InvariantTests
 	[TestMethod]
 	public void Distance_Minus_Distance_Stays_Distance()
 	{
-		Distance<double> a = Distance<double>.FromMeter(2.5);
-		Distance<double> b = Distance<double>.FromMeter(7.5);
+		Distance<double> a = Distance<double>.FromMeters(2.5);
+		Distance<double> b = Distance<double>.FromMeters(7.5);
 		Distance<double> diff = a - b;
 		Assert.AreEqual(5.0, diff.Value, Tolerance);
 		Assert.IsInstanceOfType<Distance<double>>(diff);
@@ -154,8 +154,8 @@ public sealed class Vector0InvariantTests
 	[TestMethod]
 	public void Mass_Minus_Mass_With_Float_Storage()
 	{
-		Mass<float> a = Mass<float>.FromKilogram(1.0f);
-		Mass<float> b = Mass<float>.FromKilogram(4.0f);
+		Mass<float> a = Mass<float>.FromKilograms(1.0f);
+		Mass<float> b = Mass<float>.FromKilograms(4.0f);
 		Mass<float> diff = a - b;
 		Assert.AreEqual(3.0f, diff.Value, 1e-6f);
 	}
@@ -163,8 +163,8 @@ public sealed class Vector0InvariantTests
 	[TestMethod]
 	public void Mass_Minus_Mass_With_Decimal_Storage()
 	{
-		Mass<decimal> a = Mass<decimal>.FromKilogram(1m);
-		Mass<decimal> b = Mass<decimal>.FromKilogram(4m);
+		Mass<decimal> a = Mass<decimal>.FromKilograms(1m);
+		Mass<decimal> b = Mass<decimal>.FromKilograms(4m);
 		Mass<decimal> diff = a - b;
 		Assert.AreEqual(3m, diff.Value);
 	}

--- a/Semantics.Test/Quantities/VectorQuantityTests.cs
+++ b/Semantics.Test/Quantities/VectorQuantityTests.cs
@@ -148,8 +148,8 @@ public sealed class VectorQuantityTests
 	[TestMethod]
 	public void Mass_Plus_Mass_Returns_Mass()
 	{
-		Mass<double> a = Mass<double>.FromKilogram(3.0);
-		Mass<double> b = Mass<double>.FromKilogram(5.0);
+		Mass<double> a = Mass<double>.FromKilograms(3.0);
+		Mass<double> b = Mass<double>.FromKilograms(5.0);
 		Mass<double> sum = a + b;
 		Assert.AreEqual(8.0, sum.Value, Tolerance);
 		Assert.IsInstanceOfType<Mass<double>>(sum);
@@ -173,8 +173,8 @@ public sealed class VectorQuantityTests
 	[Ignore("Locked in #52: V0 - V0 should return the same V0 of T.Abs(a - b). Generator currently emits unsigned subtraction.")]
 	public void Mass_Minus_Mass_Returns_Absolute_Difference_Pending52()
 	{
-		Mass<double> a = Mass<double>.FromKilogram(3.0);
-		Mass<double> b = Mass<double>.FromKilogram(5.0);
+		Mass<double> a = Mass<double>.FromKilograms(3.0);
+		Mass<double> b = Mass<double>.FromKilograms(5.0);
 		Mass<double> diff = a - b;
 		Assert.AreEqual(2.0, diff.Value, Tolerance);
 	}
@@ -196,7 +196,7 @@ public sealed class VectorQuantityTests
 	public void Mass_From_Negative_Throws_Pending50()
 	{
 		_ = Assert.ThrowsExactly<System.ArgumentException>(
-			() => Mass<double>.FromKilogram(-1.0));
+			() => Mass<double>.FromKilograms(-1.0));
 	}
 
 	// -------------------------------------------------- Magnitude on V1

--- a/docs/complete-library-guide.md
+++ b/docs/complete-library-guide.md
@@ -144,17 +144,17 @@ The model and its rationale live in `strategy-unified-vector-quantities.md`. Rul
 ```csharp
 // Vector0 — magnitudes (non-negative)
 var speed     = Speed<double>.FromMetersPerSecond(15.0);
-var mass      = Mass<double>.FromKilogram(10.0);
-var distance  = Distance<double>.FromMeter(5.0);
-var energy    = Energy<double>.FromJoule(1_000.0);
+var mass      = Mass<double>.FromKilograms(10.0);
+var distance  = Distance<double>.FromMeters(5.0);
+var energy    = Energy<double>.FromJoules(1_000.0);
 
 // Vector1 — signed scalar
 var v1        = Velocity1D<double>.FromMetersPerSecond(-3.5);
-var temp      = Temperature<double>.FromKelvin(300.0);
+var temp      = Temperature<double>.FromKelvins(300.0);
 
 // Vector3 — directional
-var force3d   = Force3D<double>.FromNewton(0.0, 0.0, -9.8);
-var disp3d    = Displacement3D<double>.FromMeter(3.0, 4.0, 0.0);
+var force3d   = Force3D<double>.FromNewtons(0.0, 0.0, -9.8);
+var disp3d    = Displacement3D<double>.FromMeters(3.0, 4.0, 0.0);
 ```
 
 ### Operators and dimensional analysis
@@ -163,9 +163,9 @@ Cross-dimensional operators are declared in `dimensions.json` and emitted automa
 
 ```csharp
 // V0 × V0 (magnitudes)
-var force      = mass * Acceleration<double>.FromMeter(9.8);  // Mass × Accel = Force
-var work       = ForceMagnitude<double>.FromNewton(10.0) * distance;  // F·d = Energy
-var power      = work / Duration<double>.FromSecond(2.0);     // W/t = Power
+var force      = mass * Acceleration<double>.FromMeters(9.8);  // Mass × Accel = Force
+var work       = ForceMagnitude<double>.FromNewtons(10.0) * distance;  // F·d = Energy
+var power      = work / Duration<double>.FromSeconds(2.0);     // W/t = Power
 
 // Vector ops
 var workScalar = force3d.Dot(disp3d);                          // Energy
@@ -183,7 +183,7 @@ Several dimensions declare narrower-named overloads with implicit widening:
 ```csharp
 var w   = Weight<double>.From(force);                   // Weight is a ForceMagnitude
 var fm  = ForceMagnitude<double>.From(w);               // implicit widening also OK
-var d   = Distance<double>.FromMeter(10.0);
+var d   = Distance<double>.FromMeters(10.0);
 var rad = Radius<double>.From(d);
 var dia = rad.ToDiameter();                             // 20m via metadata-defined relationship
 ```

--- a/docs/physics-domains-guide.md
+++ b/docs/physics-domains-guide.md
@@ -29,10 +29,10 @@ Seven base dimensions:
 - `LuminousIntensity` — V0.
 
 ```csharp
-var height   = Height<double>.FromMeter(1.75);
-var atomic   = AtomicMass<double>.FromKilogram(1.66e-27);
-var lifetime = Lifetime<double>.FromSecond(3600);
-var temp     = Temperature<double>.FromKelvin(298.15);
+var height   = Height<double>.FromMeters(1.75);
+var atomic   = AtomicMass<double>.FromKilograms(1.66e-27);
+var lifetime = Lifetime<double>.FromSeconds(3600);
+var temp     = Temperature<double>.FromKelvins(298.15);
 ```
 
 ## Geometry and kinematics
@@ -57,7 +57,7 @@ var sampling   = SamplingRate<double>.FromHertz(48_000);
 - `MomentOfInertia` — V0.
 
 ```csharp
-var heading = Heading<double>.FromRadian(Math.PI / 2);     // V0 overload of AngularDisplacement
+var heading = Heading<double>.FromRadians(Math.PI / 2);     // V0 overload of AngularDisplacement
 var omega3d = AngularVelocity3D<double>.FromRadianPerSecond(0.0, 0.0, 1.5);
 ```
 
@@ -71,9 +71,9 @@ var omega3d = AngularVelocity3D<double>.FromRadianPerSecond(0.0, 0.0, 1.5);
 - `Density` — V0.
 
 ```csharp
-var weight = Weight<double>.From(ForceMagnitude<double>.FromNewton(686.0));
-var drag   = Drag<double>.FromNewton(20.0);
-var pe     = PotentialEnergy<double>.FromJoule(500.0);
+var weight = Weight<double>.From(ForceMagnitude<double>.FromNewtons(686.0));
+var drag   = Drag<double>.FromNewtons(20.0);
+var pe     = PotentialEnergy<double>.FromJoules(500.0);
 ```
 
 ## Thermal
@@ -96,8 +96,8 @@ Heat itself is currently expressed via `Energy` (and its `ThermalEnergy` overloa
 - `MagneticFlux` — V0.
 
 ```csharp
-var v   = Voltage<double>.FromVolt(12.0);
-var i   = ElectricCurrent<double>.FromAmpere(2.0);
+var v   = Voltage<double>.FromVolts(12.0);
+var i   = ElectricCurrent<double>.FromAmperes(2.0);
 var r   = v / i;                                  // ElectricResistance<double>
 var p   = v * i;                                  // Power<double>
 ```
@@ -110,8 +110,8 @@ var p   = v * i;                                  // Power<double>
 - `Irradiance` — V0 with overloads `RadiantExitance`, `Radiance`, `RadiantIntensity`.
 
 ```csharp
-var flux  = LuminousFlux<double>.FromLumen(800.0);
-var lux   = flux / Area<double>.FromSquareMeter(4.0);   // Illuminance<double>
+var flux  = LuminousFlux<double>.FromLumens(800.0);
+var lux   = flux / Area<double>.FromSquareMeters(4.0);   // Illuminance<double>
 ```
 
 ## Acoustic
@@ -143,8 +143,8 @@ var T = f.Period();                                      // Time<double>
 - `MolarEnergy` — V0 with overloads `ActivationEnergy`, `EnthalpyOfReaction`.
 
 ```csharp
-var n     = AmountOfSubstance<double>.FromMole(0.5);
-var V     = Volume<double>.FromCubicMeter(0.002);          // 2 L
+var n     = AmountOfSubstance<double>.FromMoles(0.5);
+var V     = Volume<double>.FromCubicMeters(0.002);          // 2 L
 var M     = n / V;                                         // Concentration<double>
 ```
 
@@ -172,22 +172,22 @@ Speed<double>      s = v.Magnitude();   // 5.0, always >= 0
 ### Cross product (V3 only)
 
 ```csharp
-Force3D<double>        F = Force3D<double>.FromNewton(0.0, 10.0, 0.0);
-Displacement3D<double> r = Displacement3D<double>.FromMeter(0.5, 0.0, 0.0);
+Force3D<double>        F = Force3D<double>.FromNewtons(0.0, 10.0, 0.0);
+Displacement3D<double> r = Displacement3D<double>.FromMeters(0.5, 0.0, 0.0);
 Torque3D<double>       τ = F.Cross(r);
 ```
 
 ### Dot product
 
 ```csharp
-Energy<double> work = Force3D<double>.FromNewton(10.0, 0.0, 0.0)
-                          .Dot(Displacement3D<double>.FromMeter(2.0, 0.0, 0.0));   // 20 J
+Energy<double> work = Force3D<double>.FromNewtons(10.0, 0.0, 0.0)
+                          .Dot(Displacement3D<double>.FromMeters(2.0, 0.0, 0.0));   // 20 J
 ```
 
 ### Semantic overload narrowing
 
 ```csharp
-ForceMagnitude<double> raw    = ForceMagnitude<double>.FromNewton(686.0);
+ForceMagnitude<double> raw    = ForceMagnitude<double>.FromNewtons(686.0);
 Weight<double>         weight = Weight<double>.From(raw);    // explicit narrow
 ForceMagnitude<double> back   = weight;                       // implicit widen
 ```
@@ -196,9 +196,9 @@ ForceMagnitude<double> back   = weight;                       // implicit widen
 
 ```csharp
 var R    = PhysicalConstants.Generic.GasConstant<double>();          // J/(mol·K)
-var n    = AmountOfSubstance<double>.FromMole(1.0);
-var T    = Temperature<double>.FromKelvin(273.15);
-var P    = Pressure<double>.FromPascal(101_325.0);
+var n    = AmountOfSubstance<double>.FromMoles(1.0);
+var T    = Temperature<double>.FromKelvins(273.15);
+var P    = Pressure<double>.FromPascals(101_325.0);
 
 // PV = nRT  →  V = nRT / P
 // (constants flow into operators because everything stores SI base units)

--- a/docs/strategy-unified-vector-quantities.md
+++ b/docs/strategy-unified-vector-quantities.md
@@ -58,6 +58,20 @@ IQuantity<T>                          // Root: all quantities
     └── ...
 ```
 
+### Form Coverage Matrix
+
+Not every dimension declares every form. The coverage is intentional and follows three patterns; new dimensions should pick the matching one:
+
+| Dimension family | Forms | Rationale |
+|---|---|---|
+| Linear motion: `Length`, `Velocity`, `Acceleration`, `Jerk`, `Snap`, `Force`, `Momentum`, `Displacement`, `ElectricField` | V0–V4 | Pure linear vectors; every dimensionality is meaningful. |
+| Angular motion: `AngularDisplacement`, `AngularVelocity`, `AngularAcceleration`, `AngularJerk`, `Torque`, `AngularMomentum` | V0, V1, V3 | Pseudovectors. 2D / 4D forms aren't physically meaningful; skip them. |
+| Electric current: `ElectricCurrent` | V0, V1, V3 | Same as angular — no 2D current. |
+| Scalar-only: `Mass`, `Energy`, `Area`, `Volume`, `Time`, `Frequency`, `RadioactiveActivity`, `MomentOfInertia`, etc. | V0 (sometimes + V1) | Inherently scalar. Add V1 only when a signed *delta* makes physical sense (e.g. `Temperature` (V0) + `TemperatureDelta` (V1), `ElectricCharge` is V1 because charge is signed). |
+| Dimensionless / angular ratios: `Dimensionless` | V0 (`Ratio`) + V1 (`SignedRatio`) | Lets ratios that semantically must be non-negative (e.g. `MachNumber`, `RefractiveIndex`) be V0 overloads of `Ratio`, and signed ratios use `SignedRatio`. |
+
+When you declare a relationship (`integrals` / `derivatives` / `dotProducts` / `crossProducts`) the generator only emits operators for forms that exist on **both** sides — e.g. a dot product between two dimensions that both declare V3 emits the V3 dot product, while V2 is silently skipped if either side is missing. Keep this in mind when adding a new dimension: if you need it to participate in a particular relationship form, it must declare that form.
+
 ## Semantic Relationships
 
 ### Magnitude Extraction


### PR DESCRIPTION
## Summary

Closes #49 and addresses the documentation half of #58.

## #49 — plural `From{Unit}` factory naming

`UnitDefinition` gets an optional `FactoryName` field. Every entry in `units.json` now sets it explicitly:

| Group | Examples |
|---|---|
| Regular (`name + "s"`) | `Meter` → `Meters`, `Newton` → `Newtons`, `Joule` → `Joules`, `Kilogram` → `Kilograms` |
| Irregular plurals | `Foot` → `Feet`, `Inch` → `Inches`, `SquareFoot` → `SquareFeet`, `PoundFoot` → `PoundFeet`, `Henry` → `Henries` |
| Mass nouns / no-plural | `Hertz`, `Lux`, `Siemens`, `Stokes`, `Psi`, `Horsepower`, `Celsius`, `Fahrenheit`, `Gauss`, `Poise`, `Dimensionless` |
| "Per" compounds (already plural-reading) | `MetersPerSecond`, `KilometersPerHour`, `RadiansPerSecond`, `JoulePerKelvin`, … all kept as-is |

`QuantitiesGenerator.AddUnitFactories` reads `FactoryName` from the unit map and falls back to `name + "s"` when absent — correct for regulars and keeps unmigrated metadata building.

The new factory shape now matches what `CLAUDE.md` and `docs/strategy-unified-vector-quantities.md` have advertised all along (`Speed.FromMetersPerSecond`, `Force1D.FromNewtons`, etc.).

The V0 non-negativity guard from #50 and the V0 − V0 absolute subtraction operator from #52 are unchanged — only the factory *name* changed, not its body or argument shape.

## #58 (part 1) — form coverage matrix

Added a "Form Coverage Matrix" section to `docs/strategy-unified-vector-quantities.md` writing down what was previously implicit:

- Linear motion (Length / Velocity / Acceleration / Jerk / Snap / Force / Momentum / Displacement / ElectricField) → V0–V4
- Angular motion (Angular* / Torque) → V0, V1, V3 (pseudovectors; no 2D / 4D forms)
- Electric current → V0, V1, V3
- Scalar-only (Mass / Energy / Area / Time / Frequency / …) → V0 (+ V1 when a signed delta makes sense)
- Dimensionless → V0 `Ratio` + V1 `SignedRatio`

Plus a paragraph clarifying that the generator silently skips a relationship's form when either side doesn't declare it, so a new dimension has to declare every form it needs to participate in.

The SEM003 piece of #58 — a generator-time validator that fails fast when a relationship references a form the dimension doesn't declare — needs a metadata schema change first (current relationships are dimension-to-dimension, not form-specific). Not in this PR; comment on #58 explains.

## Migration impact

Renames affect every call site of generated `From{Unit}` factories. Updated in this PR:

- `Semantics.Test/Quantities/{MultiUnitFactoryTests,Vector0InvariantTests,VectorQuantityTests,SemanticOverloadTests}.cs` (call sites + method names)
- `docs/physics-domains-guide.md`, `docs/complete-library-guide.md` (example call sites)

External consumers calling singular forms (`FromMeter`, `FromKilogram`, etc.) will need to switch to the plural — this is a deliberate breaking change to fix the inconsistency.

## Test plan

- [x] `dotnet build Semantics.SourceGenerators` — clean
- [x] `dotnet build Semantics.Quantities` — generator runs cleanly (no SEM001/SEM002 warnings); 105 generated `*.g.cs` files updated to plural factory names; spot-checked Length / Mass / Temperature / Velocity1D / Frequency / Acceleration1D look right.
- [ ] `dotnet test` — `Semantics.Test` cannot restore in this sandbox (`Microsoft.NETCore.App.Host.ubuntu.24.04-x64` not in feeds); CI will run the rewritten tests.

https://claude.ai/code/session_01Tj63Rddvs9frqLUgsjNEP5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tj63Rddvs9frqLUgsjNEP5)_