### PR TITLE
feat(generator): SEM003 diagnostic + form-specific relationships (closes #58)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ var converted = sourceString.As<SourceType, TargetType>();
 - Generator diagnostics:
   - **SEM001** — a relationship in `dimensions.json` references a dimension that does not exist (typo or rename). The operator is silently dropped.
   - **SEM002** — schema-level validation issue (missing `name`/`symbol`, empty `availableUnits`, duplicate type names, no vector forms declared).
+  - **SEM003** — a relationship's explicit `forms` list references a vector form not declared on a participating dimension. Use `forms` to constrain a relationship to specific vector forms (e.g. `crossProducts: [{ "other": "Length", "result": "Torque", "forms": [3] }]`); when omitted, the legacy "emit at every common form" behaviour is preserved.
 - See `docs/physics-generator.md` for the full schema and an end-to-end "add a dimension" walk-through.
 
 This file is the entry point. For deeper material:

--- a/Semantics.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/Semantics.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|------
 SEM001  | Semantics.SourceGenerators | Warning | Reports relationships in dimensions.json that reference unknown dimension names.
 SEM002  | Semantics.SourceGenerators | Warning | Reports schema-level validation issues in dimensions.json (missing fields, duplicate type names, etc).
+SEM003  | Semantics.SourceGenerators | Warning | Reports a relationship whose explicit `forms` list references a vector form not declared on a participating dimension.

--- a/Semantics.SourceGenerators/Generators/QuantitiesGenerator.cs
+++ b/Semantics.SourceGenerators/Generators/QuantitiesGenerator.cs
@@ -37,6 +37,14 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 		defaultSeverity: DiagnosticSeverity.Warning,
 		isEnabledByDefault: true);
 
+	private static readonly DiagnosticDescriptor RelationshipFormMissing = new(
+		id: "SEM003",
+		title: "Relationship requires a vector form not declared on a participating dimension",
+		messageFormat: "Relationship in dimension '{0}' ({1}) explicitly requests form V{2}, but '{3}' does not declare that form. The operator will not be generated.",
+		category: "Semantics.SourceGenerators",
+		defaultSeverity: DiagnosticSeverity.Warning,
+		isEnabledByDefault: true);
+
 	public QuantitiesGenerator() : base("dimensions.json") { }
 
 	/// <summary>
@@ -244,7 +252,17 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 					continue;
 				}
 
-				int[] forms = [0, 1, 2, 3, 4];
+				// For integrals the "Other" multiplier is V0 only; the form propagates
+				// between Self and Result, so SEM003 should fire if either Self or
+				// Result is missing a declared form. (V0-only Other was already
+				// rejected above via the v0Other null check.)
+				int[] forms = ResolveForms(
+					context,
+					integral,
+					[0, 1, 2, 3, 4],
+					dim,
+					resultDim,
+					$"integrals[{integral.Other} -> {integral.Result}]");
 				foreach (int vn in forms)
 				{
 					string? selfType = GetBaseTypeName(dim, vn);
@@ -289,7 +307,13 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 					continue;
 				}
 
-				int[] forms = [0, 1, 2, 3, 4];
+				int[] forms = ResolveForms(
+					context,
+					derivative,
+					[0, 1, 2, 3, 4],
+					dim,
+					resultDim,
+					$"derivatives[{derivative.Other} -> {derivative.Result}]");
 				foreach (int vn in forms)
 				{
 					string? selfType = GetBaseTypeName(dim, vn);
@@ -340,8 +364,14 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 					continue;
 				}
 
-				// Dot product for V1+ forms where both self and other have that form
-				int[] forms = [1, 2, 3, 4];
+				// Dot product is undefined for V0; default forms are V1+.
+				int[] forms = ResolveForms(
+					context,
+					dot,
+					[1, 2, 3, 4],
+					dim,
+					otherDim,
+					$"dotProducts[{dot.Other} -> {dot.Result}]");
 				foreach (int vn in forms)
 				{
 					string? selfType = GetBaseTypeName(dim, vn);
@@ -371,6 +401,23 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 				if (!dimMap.TryGetValue(cross.Result, out PhysicalDimension? resultDim))
 				{
 					ReportUnknownReference(context, dim.Name, cross.Result, $"crossProducts[{cross.Other} -> {cross.Result}].result");
+					continue;
+				}
+
+				// Cross product is intrinsically 3D. Default to V3 only; explicit Forms
+				// other than [3] are accepted but the operator emit below only handles V3.
+				// Pass resultDim so SEM003 surfaces when the declared form is missing on
+				// the result type too (e.g. Force × Length → Torque at V2: Torque has no V2).
+				int[] forms = ResolveForms(
+					context,
+					cross,
+					[3],
+					dim,
+					otherDim,
+					$"crossProducts[{cross.Other} -> {cross.Result}]",
+					resultDim);
+				if (Array.IndexOf(forms, 3) < 0)
+				{
 					continue;
 				}
 
@@ -416,6 +463,71 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 			owningDimension,
 			unknownReference,
 			fieldPath));
+	}
+
+	/// <summary>
+	/// Resolves the forms at which a relationship should emit operators. When the metadata
+	/// declares <see cref="RelationshipDefinition.Forms"/> explicitly, that list wins and
+	/// any form missing from one of the participating dimensions is reported as
+	/// <c>SEM003</c>. When the list is empty, returns <paramref name="defaultForms"/>
+	/// (which the caller filters silently — preserving the legacy behaviour for relationships
+	/// that haven't opted into form-specific declarations).
+	/// </summary>
+	private static int[] ResolveForms(
+		SourceProductionContext context,
+		RelationshipDefinition rel,
+		int[] defaultForms,
+		PhysicalDimension dim,
+		PhysicalDimension otherDim,
+		string fieldPath,
+		PhysicalDimension? resultDim = null)
+	{
+		if (rel.Forms.Count == 0)
+		{
+			return defaultForms;
+		}
+
+		List<int> kept = [];
+		foreach (int form in rel.Forms)
+		{
+			if (form < 0 || form > 4)
+			{
+				continue;
+			}
+
+			if (GetBaseTypeName(dim, form) == null)
+			{
+				ReportFormMissing(context, dim.Name, fieldPath, form, dim.Name);
+				continue;
+			}
+
+			if (GetBaseTypeName(otherDim, form) == null)
+			{
+				ReportFormMissing(context, dim.Name, fieldPath, form, otherDim.Name);
+				continue;
+			}
+
+			if (resultDim != null && GetBaseTypeName(resultDim, form) == null)
+			{
+				ReportFormMissing(context, dim.Name, fieldPath, form, resultDim.Name);
+				continue;
+			}
+
+			kept.Add(form);
+		}
+
+		return [.. kept];
+	}
+
+	private static void ReportFormMissing(SourceProductionContext context, string owningDimension, string fieldPath, int form, string offendingDimension)
+	{
+		context.ReportDiagnostic(Diagnostic.Create(
+			RelationshipFormMissing,
+			Location.None,
+			owningDimension,
+			fieldPath,
+			form,
+			offendingDimension));
 	}
 
 	private static Dictionary<string, UnitDefinition> BuildUnitMap(UnitsMetadata units)

--- a/Semantics.SourceGenerators/Metadata/dimensions.json
+++ b/Semantics.SourceGenerators/Metadata/dimensions.json
@@ -563,7 +563,7 @@
         { "other": "Length", "result": "Energy" }
       ],
       "crossProducts": [
-        { "other": "Length", "result": "Torque" }
+        { "other": "Length", "result": "Torque", "forms": [3] }
       ]
     },
     {

--- a/Semantics.SourceGenerators/Models/DimensionsMetadata.cs
+++ b/Semantics.SourceGenerators/Models/DimensionsMetadata.cs
@@ -179,4 +179,13 @@ public class RelationshipDefinition
 {
 	public string Other { get; set; } = string.Empty;
 	public string Result { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Optional explicit list of vector forms (0..4) at which this relationship should
+	/// emit operators. When empty, the generator uses sensible defaults from the
+	/// relationship kind: <c>integrals</c>/<c>derivatives</c> default to all common forms,
+	/// <c>dotProducts</c> to V1+, <c>crossProducts</c> to V3 only. When set, missing forms
+	/// on either side surface as <c>SEM003</c> diagnostics instead of being silently dropped.
+	/// </summary>
+	public List<int> Forms { get; set; } = [];
 }

--- a/docs/strategy-unified-vector-quantities.md
+++ b/docs/strategy-unified-vector-quantities.md
@@ -223,6 +223,8 @@ The current `integrals` and `derivatives` lists are supplemented with `dotProduc
 - **`dotProducts`** (`Self · Other = Result`): Generates `.Dot()` methods on VN types (N >= 1) where both self and other have that VN form. Result is always V0 of the result dimension.
 - **`crossProducts`** (`Self × Other = Result`): Generates `.Cross()` methods only on V3 types where both self and other have V3 forms. Result is V3 of the result dimension.
 
+Each entry may also declare an explicit `forms` array (e.g. `{ "other": "Length", "result": "Torque", "forms": [3] }`). When set, the generator only emits operators at those forms; if a listed form is missing on any participating dimension, it surfaces as the `SEM003` diagnostic instead of being silently dropped. When `forms` is omitted, the generator falls back to per-relationship defaults: `[0, 1, 2, 3, 4]` for integrals/derivatives, `[1, 2, 3, 4]` for dot products, `[3]` for cross products.
+
 ### Complete Example: Velocity Dimension
 
 Given:


### PR DESCRIPTION
## Summary

Closes #58 — adds the `SEM003` diagnostic and the optional `forms` field on each relationship that the original issue called for. Pairs with the form-coverage matrix doc that landed in #72.

## What changed

`RelationshipDefinition` (in `dimensions.json`) gets an optional `forms` array (`int[]`). When present, the generator only emits operators at those vector forms; when a listed form is missing on a participating dimension, it now surfaces as `SEM003` instead of being silently dropped:

```
warning SEM003: Relationship in dimension 'Force' (crossProducts[Length -> Torque])
explicitly requests form V2, but 'Torque' does not declare that form.
The operator will not be generated.
```

When `forms` is omitted, the generator uses per-relationship defaults — preserving every emit decision currently in place:

| Relationship | Default `forms` |
|---|---|
| `integrals`, `derivatives` | `[0, 1, 2, 3, 4]` |
| `dotProducts` | `[1, 2, 3, 4]` (V0 has no dot product) |
| `crossProducts` | `[3]` (cross product is intrinsically 3D) |

Migrated the only current `crossProduct` (`Force × Length → Torque`) to `"forms": [3]` explicitly. The `Generated/` tree is unchanged — the migration just makes the V3 expectation visible in metadata.

## Verification

- Build clean: `dotnet build Semantics.SourceGenerators` and `dotnet build Semantics.Quantities` both succeed with no `SEM00x` warnings.
- `Force3D.Cross(Displacement3D) → Torque3D` is still emitted.
- Bogus-form regression check: temporarily setting `"forms": [2, 3]` on the cross product produces the expected `SEM003` against `Torque` (which has no V2). Reverting to `[3]` makes the warning go away.

## Doc updates

- `CLAUDE.md` generator diagnostics list adds `SEM003` with an example.
- `docs/strategy-unified-vector-quantities.md` describes the optional `forms` field.
- `AnalyzerReleases.Unshipped.md` adds the `SEM003` row.

## Test plan

- [x] Source-generator build clean
- [x] Quantities build clean (no SEM warnings on current metadata)
- [x] Generated/ tree unchanged vs baseline (default `forms` for `crossProducts` matches the existing V3-only emit)
- [x] Manual SEM003 fire test (set `forms: [2, 3]`, observed warning, reverted)
- [ ] `dotnet test` — `Semantics.Test` cannot restore in this sandbox (`Microsoft.NETCore.App.Host.ubuntu.24.04-x64` not in feeds); CI will run.

https://claude.ai/code/session_01Tj63Rddvs9frqLUgsjNEP5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tj63Rddvs9frqLUgsjNEP5)_