### PR TITLE
feat(generator): SEM004 diagnostic — flag dimensions.json units missing from units.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,7 @@ var converted = sourceString.As<SourceType, TargetType>();
   - **SEM001** — a relationship in `dimensions.json` references a dimension that does not exist (typo or rename). The operator is silently dropped.
   - **SEM002** — schema-level validation issue (missing `name`/`symbol`, empty `availableUnits`, duplicate type names, no vector forms declared).
   - **SEM003** — a relationship's explicit `forms` list references a vector form not declared on a participating dimension. Use `forms` to constrain a relationship to specific vector forms (e.g. `crossProducts: [{ "other": "Length", "result": "Torque", "forms": [3] }]`); when omitted, the legacy "emit at every common form" behaviour is preserved.
+  - **SEM004** — a dimension's `availableUnits` array references a unit name that isn't declared anywhere in `units.json`. Without the diagnostic the generator silently emits an identity-conversion `From{Unit}` factory, which is wrong for any non-base unit; SEM004 catches the typo at build time.
 - See `docs/physics-generator.md` for the full schema and an end-to-end "add a dimension" walk-through.
 
 This file is the entry point. For deeper material:

--- a/Semantics.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/Semantics.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ Rule ID | Category | Severity | Notes
 SEM001  | Semantics.SourceGenerators | Warning | Reports relationships in dimensions.json that reference unknown dimension names.
 SEM002  | Semantics.SourceGenerators | Warning | Reports schema-level validation issues in dimensions.json (missing fields, duplicate type names, etc).
 SEM003  | Semantics.SourceGenerators | Warning | Reports a relationship whose explicit `forms` list references a vector form not declared on a participating dimension.
+SEM004  | Semantics.SourceGenerators | Warning | Reports a `dimensions.json` `availableUnits` entry that doesn't match any unit declared in `units.json`.

--- a/Semantics.SourceGenerators/Generators/QuantitiesGenerator.cs
+++ b/Semantics.SourceGenerators/Generators/QuantitiesGenerator.cs
@@ -45,6 +45,14 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 		defaultSeverity: DiagnosticSeverity.Warning,
 		isEnabledByDefault: true);
 
+	private static readonly DiagnosticDescriptor UnknownUnitReference = new(
+		id: "SEM004",
+		title: "dimensions.json references a unit not declared in units.json",
+		messageFormat: "Unit '{0}' (referenced by dimension '{1}'.availableUnits) is not declared in units.json; the generated From{0} factory will use an identity conversion. Add the unit to units.json or fix the spelling.",
+		category: "Semantics.SourceGenerators",
+		defaultSeverity: DiagnosticSeverity.Warning,
+		isEnabledByDefault: true);
+
 	public QuantitiesGenerator() : base("dimensions.json") { }
 
 	/// <summary>
@@ -139,6 +147,13 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 		}
 
 		Dictionary<string, UnitDefinition> unitMap = BuildUnitMap(units);
+
+		// Issue #58/#48 follow-up: surface dimensions.json availableUnits entries that
+		// don't exist in units.json. The generator's BuildToBaseExpression silently falls
+		// back to identity conversion in that case, which is wrong for any non-base unit
+		// — a typo (e.g. "Kilometres" vs "Kilometers") would silently produce a factory
+		// with no scale factor. SEM004 catches that at build time.
+		ReportUnknownUnitReferences(context, metadata, unitMap);
 
 		// Phase A: Build maps and collect operators
 		Dictionary<string, PhysicalDimension> dimensionMap = BuildDimensionMap(metadata);
@@ -547,6 +562,51 @@ public class QuantitiesGenerator : GeneratorBase<DimensionsMetadata>
 		}
 
 		return map;
+	}
+
+	/// <summary>
+	/// Walks every <c>availableUnits</c> entry across the dimensions metadata and emits
+	/// <c>SEM004</c> for any unit name that doesn't appear in <paramref name="unitMap"/>.
+	/// Deduplicates by (unit, dimension) so a typo on a unit shared by many dimensions
+	/// reports once per offending dimension instead of per-form/overload.
+	/// </summary>
+	private static void ReportUnknownUnitReferences(
+		SourceProductionContext context,
+		DimensionsMetadata metadata,
+		Dictionary<string, UnitDefinition> unitMap)
+	{
+		// If units.json wasn't loaded the map is empty; treating every unit as "unknown"
+		// would flood the build log. The CombinedMetadata loader already supplies a
+		// non-null UnitsMetadata even when units.json is missing — check for that case
+		// and bail rather than report a useless wall of warnings.
+		if (unitMap.Count == 0)
+		{
+			return;
+		}
+
+		HashSet<string> seen = [];
+		foreach (PhysicalDimension dim in metadata.PhysicalDimensions)
+		{
+			foreach (string unitName in dim.AvailableUnits)
+			{
+				if (string.IsNullOrEmpty(unitName) || unitMap.ContainsKey(unitName))
+				{
+					continue;
+				}
+
+				string key = $"{dim.Name}::{unitName}";
+				if (!seen.Add(key))
+				{
+					continue;
+				}
+
+				context.ReportDiagnostic(Diagnostic.Create(
+					UnknownUnitReference,
+					Location.None,
+					unitName,
+					dim.Name));
+			}
+		}
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary

Adds a fourth generator diagnostic: `SEM004` warns when `dimensions.json`'s `availableUnits` references a unit name that doesn't appear in `units.json`.

## Why

Currently `BuildToBaseExpression` silently falls back to identity conversion when a unit is missing from `units.json`. That's wrong for any non-base unit — a typo (`"Metre"` for `"Meter"`, `"Hektopascal"` for `"Hectopascal"`) or an unmigrated unit produces a clean build with a `From{Unit}` factory whose body just passes the value through with no scaling. Verified by deliberately injecting `"Metre"` into Length's `availableUnits`:

```
warning SEM004: Unit 'Metre' (referenced by dimension 'Length'.availableUnits)
is not declared in units.json; the generated FromMetre factory will use an
identity conversion. Add the unit to units.json or fix the spelling.
```

Reverted to clean metadata before commit; current build is silent (zero `SEM00x` warnings).

## Implementation

- New `UnknownUnitReference` descriptor (id `SEM004`, warning).
- New `ReportUnknownUnitReferences` helper called once after `BuildUnitMap`. Walks every dimension's `availableUnits`, dedups by `(dimension, unitName)` so a typo on a unit shared by many dimensions reports once per offending dimension, and skips reporting entirely when `unitMap` is empty (`units.json` not loaded — avoids drowning the log if metadata loading misfires).
- Identity fallback in `BuildToBaseExpression` preserved — `SEM004` is the surfacing mechanism, not a behaviour change. Projects can promote warnings to errors via `TreatWarningsAsErrors` if they want hard failure on unknown units.

## Updates

- `AnalyzerReleases.Unshipped.md` — adds the `SEM004` row.
- `CLAUDE.md` — adds `SEM004` to the generator-diagnostics list under "Working with the source generator".

## Test plan

- [x] `dotnet build Semantics.SourceGenerators` clean.
- [x] `dotnet build Semantics.Quantities` clean — no `SEM00x` warnings on current metadata.
- [x] Manual fire test: `"Meter" → "Metre"` in `dimensions.json` produces the expected `SEM004` against Length; revert restores silence.
- [x] Generated/ tree unchanged vs baseline — diagnostic is additive.

https://claude.ai/code/session_01Tj63Rddvs9frqLUgsjNEP5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tj63Rddvs9frqLUgsjNEP5)_