### PR TITLE
Backfill unit catalog + constants domains from main; fix Fahrenheit and Generic constants

### DIFF
--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.ConversionsGenerator/ConversionConstants.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.ConversionsGenerator/ConversionConstants.g.cs
@@ -25,6 +25,9 @@ internal static class ConversionConstants{
 	/// <summary>Angstrom to meter conversion: 1e-10 m/Å (exact by definition)</summary>
 	internal const double AngstromToMeters = 1e-10;
 
+	/// <summary>Nautical mile to meter conversion: 1852 m/nmi (exact by definition)</summary>
+	internal const double NauticalMileToMeters = 1852;
+
 	/// <summary>Pound mass to kilogram: 0.453592 kg/lb (exact)</summary>
 	internal const double PoundMassToKilogram = 0.453592;
 
@@ -37,11 +40,41 @@ internal static class ConversionConstants{
 	/// <summary>Metric ton to kilogram conversion: 1000 kg/t (exact by definition)</summary>
 	internal const double TonToKilograms = 1000;
 
+	/// <summary>Stone to kilogram conversion: 6.35029318 kg/st (14 lb, exact)</summary>
+	internal const double StoneToKilograms = 6.35029318;
+
+	/// <summary>Short ton to kilogram conversion: 907.18474 kg/ton (2000 lb, exact)</summary>
+	internal const double ShortTonToKilograms = 907.18474;
+
+	/// <summary>Atomic mass unit to kilogram: 1.66053906660e-27 kg/u (2018 CODATA)</summary>
+	internal const double AtomicMassUnitToKilograms = 1.66053906660e-27;
+
 	/// <summary>Liter to cubic meter conversion: 0.001 m³/L (exact by definition)</summary>
 	internal const double LiterToCubicMeters = 0.001;
 
 	/// <summary>US gallon to cubic meter conversion: 0.003785411784 m³/gal (exact)</summary>
 	internal const double GallonToCubicMeters = 0.003785411784;
+
+	/// <summary>Cubic centimeter to cubic meter: 1e-6 m³/cm³ (exact by definition)</summary>
+	internal const double CubicCentimeterToCubicMeters = 1e-6;
+
+	/// <summary>Cubic foot to cubic meter: 0.028316846592 m³/ft³ (exact)</summary>
+	internal const double CubicFootToCubicMeters = 0.028316846592;
+
+	/// <summary>Cubic inch to cubic meter: 1.6387064e-5 m³/in³ (exact)</summary>
+	internal const double CubicInchToCubicMeters = 1.6387064e-5;
+
+	/// <summary>Imperial gallon to cubic meter: 0.00454609 m³/imp gal (exact by definition)</summary>
+	internal const double ImperialGallonToCubicMeters = 0.00454609;
+
+	/// <summary>US liquid quart to cubic meter: 0.000946352946 m³/qt (exact)</summary>
+	internal const double USQuartToCubicMeters = 0.000946352946;
+
+	/// <summary>US liquid pint to cubic meter: 0.000473176473 m³/pt (exact)</summary>
+	internal const double USPintToCubicMeters = 0.000473176473;
+
+	/// <summary>US fluid ounce to cubic meter: 2.95735295625e-5 m³/fl oz (exact)</summary>
+	internal const double USFluidOunceToCubicMeters = 2.95735295625e-5;
 
 	/// <summary>Minute to second conversion: 60 s/min (exact)</summary>
 	internal const double MinuteToSeconds = 60;
@@ -55,17 +88,26 @@ internal static class ConversionConstants{
 	/// <summary>Year to second conversion: 31557600 s/year (365.25 days, exact)</summary>
 	internal const double YearToSeconds = 31557600;
 
+	/// <summary>Week to second conversion: 604800 s/wk (exact)</summary>
+	internal const double WeekToSeconds = 604800;
+
 	/// <summary>Celsius to Kelvin temperature offset: 273.15 K (exact by definition)</summary>
 	internal const double CelsiusToKelvinOffset = 273.15;
 
-	/// <summary>Fahrenheit degree scale factor: 9/5 = 1.8 (exact)</summary>
-	internal const double FahrenheitScale = 1.8;
+	/// <summary>Fahrenheit-to-Kelvin degree scale factor: 5/9 (exact)</summary>
+	internal const double FahrenheitScale = 0.5555555555555556;
 
-	/// <summary>Fahrenheit to Kelvin absolute offset: -459.67 K (exact)</summary>
-	internal const double FahrenheitToKelvinOffset = -459.67;
+	/// <summary>Fahrenheit to Kelvin affine offset: 459.67 × 5/9 ≈ 255.372 K (exact)</summary>
+	internal const double FahrenheitToKelvinOffset = 255.37222222222223;
 
 	/// <summary>Degree to radian conversion: π/180 rad/° (exact)</summary>
 	internal const double DegreeToRadians = 0.017453292519943295769236907684886127134428718885417254560971914401710091146034494436822415696345097379101040706699150667990539631694451077627806983;
+
+	/// <summary>Gradian to radian conversion: π/200 rad/grad (exact)</summary>
+	internal const double GradianToRadians = 0.015707963267948966;
+
+	/// <summary>Revolution to radian conversion: 2π rad/rev (exact)</summary>
+	internal const double RevolutionToRadians = 6.283185307179586;
 
 	/// <summary>Calorie to joule conversion: 4.184 J/cal (exact, thermochemical calorie)</summary>
 	internal const double CalorieToJoules = 4.184;
@@ -79,6 +121,18 @@ internal static class ConversionConstants{
 	/// <summary>Electron volt to joule conversion: 1.602176634e-19 J/eV (exact, based on elementary charge)</summary>
 	internal const double ElectronVoltToJoules = 1.602176634e-19;
 
+	/// <summary>Kilocalorie to joule conversion: 4184 J/kcal (exact, thermochemical)</summary>
+	internal const double KilocalorieToJoules = 4184;
+
+	/// <summary>Watt-hour to joule conversion: 3600 J/Wh (exact)</summary>
+	internal const double WattHourToJoules = 3600;
+
+	/// <summary>Erg to joule conversion: 1e-7 J/erg (exact by definition)</summary>
+	internal const double ErgToJoules = 1e-7;
+
+	/// <summary>British thermal unit (IT) to joule conversion: 1055.05585262 J/BTU (exact)</summary>
+	internal const double BtuToJoules = 1055.05585262;
+
 	/// <summary>Bar to pascal conversion: 100000 Pa/bar (exact by definition)</summary>
 	internal const double BarToPascals = 100000;
 
@@ -87,6 +141,9 @@ internal static class ConversionConstants{
 
 	/// <summary>PSI to pascal conversion: 6894.757293168361 Pa/psi (exact)</summary>
 	internal const double PsiToPascals = 6894.757293168361;
+
+	/// <summary>Torr to pascal conversion: 101325/760 ≈ 133.322 Pa/Torr (exact)</summary>
+	internal const double TorrToPascals = 133.32236842105263;
 
 	/// <summary>Square foot to square meter conversion: 0.09290304 m²/ft² (exact)</summary>
 	internal const double SquareFootToSquareMeters = 0.09290304;
@@ -97,11 +154,32 @@ internal static class ConversionConstants{
 	/// <summary>Barn to square meter conversion: 1e-28 m² (exact by definition)</summary>
 	internal const double BarnToSquareMeters = 1e-28;
 
+	/// <summary>Square kilometer to square meter: 1e6 m²/km² (exact by definition)</summary>
+	internal const double SquareKilometerToSquareMeters = 1e6;
+
+	/// <summary>Square centimeter to square meter: 1e-4 m²/cm² (exact by definition)</summary>
+	internal const double SquareCentimeterToSquareMeters = 1e-4;
+
+	/// <summary>Square mile to square meter: 2589988.110336 m²/mi² (exact)</summary>
+	internal const double SquareMileToSquareMeters = 2589988.110336;
+
+	/// <summary>Hectare to square meter: 10000 m²/ha (exact by definition)</summary>
+	internal const double HectareToSquareMeters = 10000;
+
+	/// <summary>Acre to square meter: 4046.8564224 m²/ac (exact)</summary>
+	internal const double AcreToSquareMeters = 4046.8564224;
+
 	/// <summary>Kilometers per hour to meters per second conversion: 0.2777777777777778 m/s per km/h (exact)</summary>
 	internal const double KilometersPerHourToMetersPerSecond = 0.2777777777777778;
 
 	/// <summary>Miles per hour to meters per second conversion: 0.44704 m/s per mph (exact)</summary>
 	internal const double MilesPerHourToMetersPerSecond = 0.44704;
+
+	/// <summary>Feet per second to meters per second: 0.3048 m/s per ft/s (exact)</summary>
+	internal const double FeetPerSecondToMetersPerSecond = 0.3048;
+
+	/// <summary>Knot to meters per second: 1852/3600 ≈ 0.514444 m/s per kn (exact)</summary>
+	internal const double KnotToMetersPerSecond = 0.5144444444444445;
 
 	/// <summary>RPM to rad/s conversion: π/30 rad/s per rpm (exact)</summary>
 	internal const double RevolutionsPerMinuteToRadiansPerSecond = 0.10471975511965977;
@@ -112,6 +190,12 @@ internal static class ConversionConstants{
 	/// <summary>Molar to cubic meter concentration conversion: 1000.0 mol/m³ per mol/L (exact)</summary>
 	internal const double MolarToCubicMeter = 1000.0;
 
+	/// <summary>Millimolar to mole per cubic meter: 1 mol/m³ per mM (exact)</summary>
+	internal const double MillimolarToMolePerCubicMeter = 1.0;
+
+	/// <summary>Micromolar to mole per cubic meter: 0.001 mol/m³ per μM (exact)</summary>
+	internal const double MicromolarToMolePerCubicMeter = 0.001;
+
 	/// <summary>Stokes to square meter per second: 1e-4 m²/s per St (exact by definition)</summary>
 	internal const double StokesToSquareMeterPerSecond = 1e-4;
 
@@ -121,14 +205,68 @@ internal static class ConversionConstants{
 	/// <summary>Liter per second to cubic meter per second: 0.001 m³/s per L/s (exact by definition)</summary>
 	internal const double LiterPerSecondToCubicMeterPerSecond = 0.001;
 
+	/// <summary>Centipoise to pascal second: 0.001 Pa·s per cP (exact by definition)</summary>
+	internal const double CentipoiseToPascalSecond = 0.001;
+
+	/// <summary>Dyne per centimeter to newton per meter: 0.001 N/m per dyn/cm (exact)</summary>
+	internal const double DynePerCentimeterToNewtonPerMeter = 0.001;
+
+	/// <summary>Gram per cubic centimeter to kilogram per cubic meter: 1000 kg/m³ per g/cm³ (exact)</summary>
+	internal const double GramPerCubicCentimeterToKilogramPerCubicMeter = 1000;
+
+	/// <summary>Gram per liter to kilogram per cubic meter: 1 kg/m³ per g/L (exact)</summary>
+	internal const double GramPerLiterToKilogramPerCubicMeter = 1.0;
+
 	/// <summary>Gauss to Tesla: 1e-4 T per G (exact by definition)</summary>
 	internal const double GaussToTesla = 1e-4;
+
+	/// <summary>Ampere-hour to coulomb conversion: 3600 C/Ah (exact)</summary>
+	internal const double AmpereHourToCoulombs = 3600;
 
 	/// <summary>Gram per mole to kilogram per mole: 0.001 kg/mol per g/mol (exact by definition)</summary>
 	internal const double GramPerMoleToKilogramPerMole = 0.001;
 
 	/// <summary>Kilojoule per mole to joule per mole: 1000 J/mol per kJ/mol (exact by definition)</summary>
 	internal const double KilojoulePerMoleToJoulePerMole = 1000;
+
+	/// <summary>Calorie per mole to joule per mole: 4.184 J/mol per cal/mol (exact, thermochemical)</summary>
+	internal const double CaloriePerMoleToJoulePerMole = 4.184;
+
+	/// <summary>Enzyme unit (1 μmol/min) to katal: 1/6e7 ≈ 1.6667e-8 kat/U (exact)</summary>
+	internal const double EnzymeUnitToKatals = 1.6666666666666667e-8;
+
+	/// <summary>Standard gravity to meters per second squared: 9.80665 m/s² per g (exact by definition)</summary>
+	internal const double StandardGravityToMetersPerSecondSquared = 9.80665;
+
+	/// <summary>Dyne to newton conversion: 1e-5 N/dyn (exact by definition)</summary>
+	internal const double DyneToNewtons = 1e-5;
+
+	/// <summary>Pound-force to newton conversion: 4.4482216152605 N/lbf (exact)</summary>
+	internal const double PoundForceToNewtons = 4.4482216152605;
+
+	/// <summary>Curie to becquerel conversion: 3.7e10 Bq/Ci (exact by definition)</summary>
+	internal const double CurieToBecquerels = 3.7e10;
+
+	/// <summary>Rad to gray conversion: 0.01 Gy/rad (exact by definition)</summary>
+	internal const double RadToGrays = 0.01;
+
+	/// <summary>Rem to sievert conversion: 0.01 Sv/rem (exact by definition)</summary>
+	internal const double RemToSieverts = 0.01;
+
+	/// <summary>Roentgen to coulomb per kilogram: 2.58e-4 C/kg per R (exact by definition)</summary>
+	internal const double RoentgenToCoulombsPerKilogram = 2.58e-4;
+
+	/// <summary>Foot-candle to lux conversion: 1/0.09290304 ≈ 10.7639 lx/fc (exact)</summary>
+	internal const double FootCandleToLux = 10.763910416709722;
+
+	/// <summary>Parts per million to ratio: 1e-6 (exact by definition)</summary>
+	internal const double PartsPerMillionToRatio = 1e-6;
+
+	/// <summary>Parts per billion to ratio: 1e-9 (exact by definition)</summary>
+	internal const double PartsPerBillionToRatio = 1e-9;
+
+	/// <summary>Percent by weight to mass-fraction ratio: 0.01 (exact by definition)</summary>
+	internal const double PercentByWeightToRatio = 0.01;
 
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.PhysicalConstantsGenerator/PhysicalConstants.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.PhysicalConstantsGenerator/PhysicalConstants.g.cs
@@ -16,6 +16,24 @@ using ktsu.PreciseNumber;
 public static class PhysicalConstants{
 
 	/// <summary>
+	/// The physics of sound and vibration, including wave propagation, acoustic properties, sound intensity, frequency analysis, and audio-related measurements
+	/// </summary>
+	public static class Acoustics{
+		/// <summary>Reference sound intensity: 1 × 10⁻¹² W/m² (threshold of hearing)</summary>
+		public static readonly PreciseNumber ReferenceSoundIntensity = PreciseNumber.Parse("1e-12", CultureInfo.InvariantCulture);
+
+		/// <summary>Reference sound power: 1 × 10⁻¹² W</summary>
+		public static readonly PreciseNumber ReferenceSoundPower = PreciseNumber.Parse("1e-12", CultureInfo.InvariantCulture);
+
+		/// <summary>Reference sound pressure: 20 × 10⁻⁶ Pa (threshold of hearing)</summary>
+		public static readonly PreciseNumber ReferenceSoundPressure = PreciseNumber.Parse("20e-6", CultureInfo.InvariantCulture);
+
+		/// <summary>Sabine reverberation constant: 0.161 s/m</summary>
+		public static readonly PreciseNumber SabineConstant = PreciseNumber.Parse("0.161", CultureInfo.InvariantCulture);
+
+	};
+
+	/// <summary>
 	/// Rotational motion and angular quantities, including angular velocity, angular acceleration, torque, and moment of inertia
 	/// </summary>
 	public static class AngularMechanics{
@@ -64,6 +82,18 @@ public static class PhysicalConstants{
 	};
 
 	/// <summary>
+	/// The study of fluids (liquids and gases) in motion and at rest, including fluid properties, flow dynamics, viscosity, pressure, and fluid-structure interactions
+	/// </summary>
+	public static class FluidMechanics{
+		/// <summary>Standard air density at 15°C and 1 atm: 1.225 kg/m³ (ISO 2533)</summary>
+		public static readonly PreciseNumber StandardAirDensity = PreciseNumber.Parse("1.225", CultureInfo.InvariantCulture);
+
+		/// <summary>Water surface tension at 20°C: 0.0728 N/m (NIST)</summary>
+		public static readonly PreciseNumber WaterSurfaceTension = PreciseNumber.Parse("0.0728", CultureInfo.InvariantCulture);
+
+	};
+
+	/// <summary>
 	/// Basic physical quantities and constants that form the foundation of all other physics domains, including fundamental units like length, mass, time, and universal constants
 	/// </summary>
 	public static class Fundamental{
@@ -97,6 +127,27 @@ public static class PhysicalConstants{
 	};
 
 	/// <summary>
+	/// The study of atomic nuclei, radioactivity, nuclear reactions, decay processes, and radiation interactions with matter
+	/// </summary>
+	public static class NuclearPhysics{
+		/// <summary>Atomic mass unit: 1.66053906660 × 10⁻²⁷ kg (2018 CODATA)</summary>
+		public static readonly PreciseNumber AtomicMassUnit = PreciseNumber.Parse("1.66053906660e-27", CultureInfo.InvariantCulture);
+
+		/// <summary>Nuclear magneton: 5.0507837461 × 10⁻²⁷ J/T (2018 CODATA)</summary>
+		public static readonly PreciseNumber NuclearMagneton = PreciseNumber.Parse("5.0507837461e-27", CultureInfo.InvariantCulture);
+
+	};
+
+	/// <summary>
+	/// The physics of light and optical phenomena, including electromagnetic radiation, photometry, illumination, optical properties, and light-matter interactions
+	/// </summary>
+	public static class Optics{
+		/// <summary>Luminous efficacy of monochromatic radiation at 540 THz: 683 lm/W (exact, SI defining constant)</summary>
+		public static readonly PreciseNumber LuminousEfficacy = PreciseNumber.Parse("683.0", CultureInfo.InvariantCulture);
+
+	};
+
+	/// <summary>
 	/// The physics of heat, temperature, and energy transfer, including thermal properties, heat capacity, entropy, and thermodynamic processes
 	/// </summary>
 	public static class Thermodynamics{
@@ -119,51 +170,69 @@ public static class PhysicalConstants{
 	/// </summary>
 	public static class Generic{
 		/// <summary>Gets absolute zero in celsius: 273.15 k (exact by definition) as type T.</summary>
-		public static T AbsoluteZeroInCelsius<T>() where T : struct, INumber<T> => T.CreateChecked(Thermodynamics.AbsoluteZeroInCelsius);
+		public static T AbsoluteZeroInCelsius<T>() where T : struct, INumber<T> => Thermodynamics.AbsoluteZeroInCelsius.To<T>();
+/// <summary>Gets atomic mass unit: 1.66053906660 × 10⁻²⁷ kg (2018 codata) as type T.</summary>
+		public static T AtomicMassUnit<T>() where T : struct, INumber<T> => NuclearPhysics.AtomicMassUnit.To<T>();
 /// <summary>Gets avogadro's number: 6.02214076 × 10²³ entities/mol (exact, si defining constant) as type T.</summary>
-		public static T AvogadroNumber<T>() where T : struct, INumber<T> => T.CreateChecked(Fundamental.AvogadroNumber);
+		public static T AvogadroNumber<T>() where T : struct, INumber<T> => Fundamental.AvogadroNumber.To<T>();
 /// <summary>Gets boltzmann constant: 1.380649 × 10⁻²³ j/k (exact, si defining constant) as type T.</summary>
-		public static T BoltzmannConstant<T>() where T : struct, INumber<T> => T.CreateChecked(Fundamental.BoltzmannConstant);
+		public static T BoltzmannConstant<T>() where T : struct, INumber<T> => Fundamental.BoltzmannConstant.To<T>();
 /// <summary>Gets degrees per radian: 180/π ≈ 57.29577951308232 as type T.</summary>
-		public static T DegreesPerRadian<T>() where T : struct, INumber<T> => T.CreateChecked(AngularMechanics.DegreesPerRadian);
+		public static T DegreesPerRadian<T>() where T : struct, INumber<T> => AngularMechanics.DegreesPerRadian.To<T>();
 /// <summary>Gets elementary charge: 1.602176634 × 10⁻¹⁹ c (exact, si defining constant) as type T.</summary>
-		public static T ElementaryCharge<T>() where T : struct, INumber<T> => T.CreateChecked(Fundamental.ElementaryCharge);
+		public static T ElementaryCharge<T>() where T : struct, INumber<T> => Fundamental.ElementaryCharge.To<T>();
 /// <summary>Gets fine structure constant: 7.2973525693 × 10⁻³ (dimensionless, 2018 codata) as type T.</summary>
-		public static T FineStructureConstant<T>() where T : struct, INumber<T> => T.CreateChecked(Fundamental.FineStructureConstant);
+		public static T FineStructureConstant<T>() where T : struct, INumber<T> => Fundamental.FineStructureConstant.To<T>();
 /// <summary>Gets gas constant: 8.31446261815324 j/(mol·k) (exact, derived from avogadro and boltzmann constants) as type T.</summary>
-		public static T GasConstant<T>() where T : struct, INumber<T> => T.CreateChecked(Chemistry.GasConstant);
+		public static T GasConstant<T>() where T : struct, INumber<T> => Chemistry.GasConstant.To<T>();
 /// <summary>Gets gravitational constant: 6.67430 × 10⁻¹¹ m³/(kg⋅s²) (2018 codata) as type T.</summary>
-		public static T GravitationalConstant<T>() where T : struct, INumber<T> => T.CreateChecked(Fundamental.GravitationalConstant);
+		public static T GravitationalConstant<T>() where T : struct, INumber<T> => Fundamental.GravitationalConstant.To<T>();
 /// <summary>Gets natural logarithm of 2: 0.6931471805599453 as type T.</summary>
-		public static T Ln2<T>() where T : struct, INumber<T> => T.CreateChecked(Chemistry.Ln2);
+		public static T Ln2<T>() where T : struct, INumber<T> => Chemistry.Ln2.To<T>();
+/// <summary>Gets luminous efficacy of monochromatic radiation at 540 thz: 683 lm/w (exact, si defining constant) as type T.</summary>
+		public static T LuminousEfficacy<T>() where T : struct, INumber<T> => Optics.LuminousEfficacy.To<T>();
 /// <summary>Gets molar volume of ideal gas at stp: 22.413969545014137 l/mol (calculated from r*t/p at 273.15k, 101325pa) as type T.</summary>
-		public static T MolarVolumeSTP<T>() where T : struct, INumber<T> => T.CreateChecked(Chemistry.MolarVolumeSTP);
+		public static T MolarVolumeSTP<T>() where T : struct, INumber<T> => Chemistry.MolarVolumeSTP.To<T>();
 /// <summary>Gets neutral ph value at 25°c: 7.0 as type T.</summary>
-		public static T NeutralPH<T>() where T : struct, INumber<T> => T.CreateChecked(Chemistry.NeutralPH);
+		public static T NeutralPH<T>() where T : struct, INumber<T> => Chemistry.NeutralPH.To<T>();
+/// <summary>Gets nuclear magneton: 5.0507837461 × 10⁻²⁷ j/t (2018 codata) as type T.</summary>
+		public static T NuclearMagneton<T>() where T : struct, INumber<T> => NuclearPhysics.NuclearMagneton.To<T>();
 /// <summary>Gets magnetic permeability of free space: 4π × 10⁻⁷ h/m (exact by definition) as type T.</summary>
-		public static T PermeabilityOfFreeSpace<T>() where T : struct, INumber<T> => T.CreateChecked(Fundamental.PermeabilityOfFreeSpace);
+		public static T PermeabilityOfFreeSpace<T>() where T : struct, INumber<T> => Fundamental.PermeabilityOfFreeSpace.To<T>();
 /// <summary>Gets electric permittivity of free space: 8.8541878128 × 10⁻¹² f/m (exact, derived) as type T.</summary>
-		public static T PermittivityOfFreeSpace<T>() where T : struct, INumber<T> => T.CreateChecked(Fundamental.PermittivityOfFreeSpace);
+		public static T PermittivityOfFreeSpace<T>() where T : struct, INumber<T> => Fundamental.PermittivityOfFreeSpace.To<T>();
 /// <summary>Gets planck constant: 6.62607015 × 10⁻³⁴ j·s (exact, si defining constant) as type T.</summary>
-		public static T PlanckConstant<T>() where T : struct, INumber<T> => T.CreateChecked(Fundamental.PlanckConstant);
+		public static T PlanckConstant<T>() where T : struct, INumber<T> => Fundamental.PlanckConstant.To<T>();
 /// <summary>Gets radians per degree: π/180 ≈ 0.017453292519943295 as type T.</summary>
-		public static T RadiansPerDegree<T>() where T : struct, INumber<T> => T.CreateChecked(AngularMechanics.RadiansPerDegree);
+		public static T RadiansPerDegree<T>() where T : struct, INumber<T> => AngularMechanics.RadiansPerDegree.To<T>();
+/// <summary>Gets reference sound intensity: 1 × 10⁻¹² w/m² (threshold of hearing) as type T.</summary>
+		public static T ReferenceSoundIntensity<T>() where T : struct, INumber<T> => Acoustics.ReferenceSoundIntensity.To<T>();
+/// <summary>Gets reference sound power: 1 × 10⁻¹² w as type T.</summary>
+		public static T ReferenceSoundPower<T>() where T : struct, INumber<T> => Acoustics.ReferenceSoundPower.To<T>();
+/// <summary>Gets reference sound pressure: 20 × 10⁻⁶ pa (threshold of hearing) as type T.</summary>
+		public static T ReferenceSoundPressure<T>() where T : struct, INumber<T> => Acoustics.ReferenceSoundPressure.To<T>();
+/// <summary>Gets sabine reverberation constant: 0.161 s/m as type T.</summary>
+		public static T SabineConstant<T>() where T : struct, INumber<T> => Acoustics.SabineConstant.To<T>();
 /// <summary>Gets speed of light in vacuum: 299,792,458 m/s (exact, si defining constant) as type T.</summary>
-		public static T SpeedOfLight<T>() where T : struct, INumber<T> => T.CreateChecked(Fundamental.SpeedOfLight);
+		public static T SpeedOfLight<T>() where T : struct, INumber<T> => Fundamental.SpeedOfLight.To<T>();
+/// <summary>Gets standard air density at 15°c and 1 atm: 1.225 kg/m³ (iso 2533) as type T.</summary>
+		public static T StandardAirDensity<T>() where T : struct, INumber<T> => FluidMechanics.StandardAirDensity.To<T>();
 /// <summary>Gets standard atmospheric pressure: 101,325 pa (exact by definition) as type T.</summary>
-		public static T StandardAtmosphericPressure<T>() where T : struct, INumber<T> => T.CreateChecked(ClassicalMechanics.StandardAtmosphericPressure);
+		public static T StandardAtmosphericPressure<T>() where T : struct, INumber<T> => ClassicalMechanics.StandardAtmosphericPressure.To<T>();
 /// <summary>Gets standard gravitational acceleration: 9.80665 m/s² (exact by definition) as type T.</summary>
-		public static T StandardGravity<T>() where T : struct, INumber<T> => T.CreateChecked(ClassicalMechanics.StandardGravity);
+		public static T StandardGravity<T>() where T : struct, INumber<T> => ClassicalMechanics.StandardGravity.To<T>();
 /// <summary>Gets standard temperature (stp): 273.15 k (0°c) as type T.</summary>
-		public static T StandardTemperature<T>() where T : struct, INumber<T> => T.CreateChecked(Thermodynamics.StandardTemperature);
+		public static T StandardTemperature<T>() where T : struct, INumber<T> => Thermodynamics.StandardTemperature.To<T>();
 /// <summary>Gets 2π - full rotation in radians: 6.283185307179586 as type T.</summary>
-		public static T TwoPi<T>() where T : struct, INumber<T> => T.CreateChecked(AngularMechanics.TwoPi);
+		public static T TwoPi<T>() where T : struct, INumber<T> => AngularMechanics.TwoPi.To<T>();
 /// <summary>Gets water boiling point at 1 atm: 373.15 k (100°c) as type T.</summary>
-		public static T WaterBoilingPoint<T>() where T : struct, INumber<T> => T.CreateChecked(Thermodynamics.WaterBoilingPoint);
+		public static T WaterBoilingPoint<T>() where T : struct, INumber<T> => Thermodynamics.WaterBoilingPoint.To<T>();
 /// <summary>Gets water ion product (kw) at 25°c: 1.0 × 10⁻¹⁴ (pkw = 14.0) as type T.</summary>
-		public static T WaterIonProduct<T>() where T : struct, INumber<T> => T.CreateChecked(Chemistry.WaterIonProduct);
+		public static T WaterIonProduct<T>() where T : struct, INumber<T> => Chemistry.WaterIonProduct.To<T>();
+/// <summary>Gets water surface tension at 20°c: 0.0728 n/m (nist) as type T.</summary>
+		public static T WaterSurfaceTension<T>() where T : struct, INumber<T> => FluidMechanics.WaterSurfaceTension.To<T>();
 /// <summary>Gets water triple point: 273.16 k (exact by definition) as type T.</summary>
-		public static T WaterTriplePoint<T>() where T : struct, INumber<T> => T.CreateChecked(Thermodynamics.WaterTriplePoint);
+		public static T WaterTriplePoint<T>() where T : struct, INumber<T> => Thermodynamics.WaterTriplePoint.To<T>();
 };
 };
 

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AbsorbedDose.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AbsorbedDose.g.cs
@@ -28,6 +28,13 @@ public record AbsorbedDose<T> : PhysicalQuantity<AbsorbedDose<T>, T>, IVector0<A
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static AbsorbedDose<T> FromGrays(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="AbsorbedDose{T}"/> from a value in Rad.
+	/// </summary>
+	/// <param name="value">The value in Rad.</param>
+	/// <returns>A new <see cref="AbsorbedDose{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AbsorbedDose<T> FromRads(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.RadToGrays)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-AbsorbedDose unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Acceleration1D.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Acceleration1D.g.cs
@@ -27,6 +27,12 @@ public record Acceleration1D<T> : PhysicalQuantity<Acceleration1D<T>, T>, IVecto
 	/// <returns>A new <see cref="Acceleration1D{T}"/> instance.</returns>
 	public static Acceleration1D<T> FromMetersPerSecondSquared(T value) => Create(value);
 /// <summary>
+	/// Creates a new <see cref="Acceleration1D{T}"/> from a value in StandardGravity.
+	/// </summary>
+	/// <param name="value">The value in StandardGravity.</param>
+	/// <returns>A new <see cref="Acceleration1D{T}"/> instance.</returns>
+	public static Acceleration1D<T> FromStandardGravity(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.StandardGravityToMetersPerSecondSquared)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Acceleration unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AccelerationMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AccelerationMagnitude.g.cs
@@ -28,6 +28,13 @@ public record AccelerationMagnitude<T> : PhysicalQuantity<AccelerationMagnitude<
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static AccelerationMagnitude<T> FromMetersPerSecondSquared(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="AccelerationMagnitude{T}"/> from a value in StandardGravity.
+	/// </summary>
+	/// <param name="value">The value in StandardGravity.</param>
+	/// <returns>A new <see cref="AccelerationMagnitude{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AccelerationMagnitude<T> FromStandardGravity(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.StandardGravityToMetersPerSecondSquared)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Acceleration unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ActivationEnergy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ActivationEnergy.g.cs
@@ -36,6 +36,13 @@ public record ActivationEnergy<T> : PhysicalQuantity<ActivationEnergy<T>, T>, IV
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static ActivationEnergy<T> FromKilojoulePerMole(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilojoulePerMoleToJoulePerMole)), nameof(value)));
 /// <summary>
+	/// Creates a new ActivationEnergy from a value in CaloriePerMole.
+	/// </summary>
+	/// <param name="value">The value in CaloriePerMole.</param>
+	/// <returns>A new ActivationEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ActivationEnergy<T> FromCaloriesPerMole(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CaloriePerMoleToJoulePerMole)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-MolarEnergy unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Airspeed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Airspeed.g.cs
@@ -43,6 +43,20 @@ public record Airspeed<T> : PhysicalQuantity<Airspeed<T>, T>, IVector0<Airspeed<
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Airspeed<T> FromMilesPerHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MilesPerHourToMetersPerSecond)), nameof(value)));
 /// <summary>
+	/// Creates a new Airspeed from a value in FeetPerSecond.
+	/// </summary>
+	/// <param name="value">The value in FeetPerSecond.</param>
+	/// <returns>A new Airspeed instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Airspeed<T> FromFeetPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetPerSecondToMetersPerSecond)), nameof(value)));
+/// <summary>
+	/// Creates a new Airspeed from a value in Knot.
+	/// </summary>
+	/// <param name="value">The value in Knot.</param>
+	/// <returns>A new Airspeed instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Airspeed<T> FromKnots(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KnotToMetersPerSecond)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Velocity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Altitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Altitude.g.cs
@@ -99,6 +99,13 @@ public record Altitude<T> : PhysicalQuantity<Altitude<T>, T>, IVector0<Altitude<
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Altitude<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>
+	/// Creates a new Altitude from a value in NauticalMile.
+	/// </summary>
+	/// <param name="value">The value in NauticalMile.</param>
+	/// <returns>A new Altitude instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Altitude<T> FromNauticalMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.NauticalMileToMeters)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Length unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AmountOfSubstance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AmountOfSubstance.g.cs
@@ -28,6 +28,20 @@ public record AmountOfSubstance<T> : PhysicalQuantity<AmountOfSubstance<T>, T>, 
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static AmountOfSubstance<T> FromMoles(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="AmountOfSubstance{T}"/> from a value in Kilomole.
+	/// </summary>
+	/// <param name="value">The value in Kilomole.</param>
+	/// <returns>A new <see cref="AmountOfSubstance{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AmountOfSubstance<T> FromKilomoles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="AmountOfSubstance{T}"/> from a value in Millimole.
+	/// </summary>
+	/// <param name="value">The value in Millimole.</param>
+	/// <returns>A new <see cref="AmountOfSubstance{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AmountOfSubstance<T> FromMillimoles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-AmountOfSubstance unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Angle.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Angle.g.cs
@@ -35,6 +35,27 @@ public record Angle<T> : PhysicalQuantity<Angle<T>, T>, IVector0<Angle<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Angle<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Angle{T}"/> from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new <see cref="Angle{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Angle<T> FromGradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Angle{T}"/> from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new <see cref="Angle{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Angle<T> FromRevolutions(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Angle{T}"/> from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new <see cref="Angle{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Angle<T> FromMilliradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-AngularDisplacement unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ApertureAngle.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ApertureAngle.g.cs
@@ -36,6 +36,27 @@ public record ApertureAngle<T> : PhysicalQuantity<ApertureAngle<T>, T>, IVector0
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static ApertureAngle<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>
+	/// Creates a new ApertureAngle from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new ApertureAngle instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ApertureAngle<T> FromGradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new ApertureAngle from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new ApertureAngle instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ApertureAngle<T> FromRevolutions(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new ApertureAngle from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new ApertureAngle instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ApertureAngle<T> FromMilliradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-AngularDisplacement unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Area.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Area.g.cs
@@ -28,6 +28,20 @@ public record Area<T> : PhysicalQuantity<Area<T>, T>, IVector0<Area<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Area<T> FromSquareMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Area{T}"/> from a value in SquareKilometer.
+	/// </summary>
+	/// <param name="value">The value in SquareKilometer.</param>
+	/// <returns>A new <see cref="Area{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Area<T> FromSquareKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareKilometerToSquareMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Area{T}"/> from a value in SquareCentimeter.
+	/// </summary>
+	/// <param name="value">The value in SquareCentimeter.</param>
+	/// <returns>A new <see cref="Area{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Area<T> FromSquareCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareCentimeterToSquareMeters)), nameof(value)));
+/// <summary>
 	/// Creates a new <see cref="Area{T}"/> from a value in SquareFoot.
 	/// </summary>
 	/// <param name="value">The value in SquareFoot.</param>
@@ -41,6 +55,27 @@ public record Area<T> : PhysicalQuantity<Area<T>, T>, IVector0<Area<T>, T>
 	/// <returns>A new <see cref="Area{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Area<T> FromSquareInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareInchToSquareMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Area{T}"/> from a value in SquareMile.
+	/// </summary>
+	/// <param name="value">The value in SquareMile.</param>
+	/// <returns>A new <see cref="Area{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Area<T> FromSquareMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareMileToSquareMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Area{T}"/> from a value in Hectare.
+	/// </summary>
+	/// <param name="value">The value in Hectare.</param>
+	/// <returns>A new <see cref="Area{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Area<T> FromHectares(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HectareToSquareMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Area{T}"/> from a value in Acre.
+	/// </summary>
+	/// <param name="value">The value in Acre.</param>
+	/// <returns>A new <see cref="Area{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Area<T> FromAcres(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AcreToSquareMeters)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Area unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AtmosphericPressure.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AtmosphericPressure.g.cs
@@ -29,6 +29,13 @@ public record AtmosphericPressure<T> : PhysicalQuantity<AtmosphericPressure<T>, 
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static AtmosphericPressure<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new AtmosphericPressure from a value in Kilopascal.
+	/// </summary>
+	/// <param name="value">The value in Kilopascal.</param>
+	/// <returns>A new AtmosphericPressure instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AtmosphericPressure<T> FromKilopascals(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Creates a new AtmosphericPressure from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
@@ -49,6 +56,13 @@ public record AtmosphericPressure<T> : PhysicalQuantity<AtmosphericPressure<T>, 
 	/// <returns>A new AtmosphericPressure instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static AtmosphericPressure<T> FromPsi(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PsiToPascals)), nameof(value)));
+/// <summary>
+	/// Creates a new AtmosphericPressure from a value in Torr.
+	/// </summary>
+	/// <param name="value">The value in Torr.</param>
+	/// <returns>A new AtmosphericPressure instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AtmosphericPressure<T> FromTorr(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.TorrToPascals)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Pressure unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AtomicMass.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/AtomicMass.g.cs
@@ -57,6 +57,27 @@ public record AtomicMass<T> : PhysicalQuantity<AtomicMass<T>, T>, IVector0<Atomi
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static AtomicMass<T> FromOunces(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.OunceToKilograms)), nameof(value)));
 /// <summary>
+	/// Creates a new AtomicMass from a value in Stone.
+	/// </summary>
+	/// <param name="value">The value in Stone.</param>
+	/// <returns>A new AtomicMass instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AtomicMass<T> FromStone(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.StoneToKilograms)), nameof(value)));
+/// <summary>
+	/// Creates a new AtomicMass from a value in ShortTon.
+	/// </summary>
+	/// <param name="value">The value in ShortTon.</param>
+	/// <returns>A new AtomicMass instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AtomicMass<T> FromShortTons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ShortTonToKilograms)), nameof(value)));
+/// <summary>
+	/// Creates a new AtomicMass from a value in AtomicMassUnit.
+	/// </summary>
+	/// <param name="value">The value in AtomicMassUnit.</param>
+	/// <returns>A new AtomicMass instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static AtomicMass<T> FromAtomicMassUnits(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtomicMassUnitToKilograms)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Mass unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Bandwidth.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Bandwidth.g.cs
@@ -29,6 +29,20 @@ public record Bandwidth<T> : PhysicalQuantity<Bandwidth<T>, T>, IVector0<Bandwid
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Bandwidth<T> FromHertz(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new Bandwidth from a value in Kilohertz.
+	/// </summary>
+	/// <param name="value">The value in Kilohertz.</param>
+	/// <returns>A new Bandwidth instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Bandwidth<T> FromKilohertz(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new Bandwidth from a value in Megahertz.
+	/// </summary>
+	/// <param name="value">The value in Megahertz.</param>
+	/// <returns>A new Bandwidth instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Bandwidth<T> FromMegahertz(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Mega)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Frequency unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Bearing.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Bearing.g.cs
@@ -34,6 +34,24 @@ public record Bearing<T> : PhysicalQuantity<Bearing<T>, T>, IVector1<Bearing<T>,
 	/// <returns>A new Bearing instance.</returns>
 	public static Bearing<T> FromDegrees(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
 /// <summary>
+	/// Creates a new Bearing from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new Bearing instance.</returns>
+	public static Bearing<T> FromGradians(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)));
+/// <summary>
+	/// Creates a new Bearing from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new Bearing instance.</returns>
+	public static Bearing<T> FromRevolutions(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)));
+/// <summary>
+	/// Creates a new Bearing from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new Bearing instance.</returns>
+	public static Bearing<T> FromMilliradians(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Milli)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-AngularDisplacement unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/BulkModulus.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/BulkModulus.g.cs
@@ -29,6 +29,13 @@ public record BulkModulus<T> : PhysicalQuantity<BulkModulus<T>, T>, IVector0<Bul
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static BulkModulus<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new BulkModulus from a value in Kilopascal.
+	/// </summary>
+	/// <param name="value">The value in Kilopascal.</param>
+	/// <returns>A new BulkModulus instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static BulkModulus<T> FromKilopascals(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Creates a new BulkModulus from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
@@ -49,6 +56,13 @@ public record BulkModulus<T> : PhysicalQuantity<BulkModulus<T>, T>, IVector0<Bul
 	/// <returns>A new BulkModulus instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static BulkModulus<T> FromPsi(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PsiToPascals)), nameof(value)));
+/// <summary>
+	/// Creates a new BulkModulus from a value in Torr.
+	/// </summary>
+	/// <param name="value">The value in Torr.</param>
+	/// <returns>A new BulkModulus instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static BulkModulus<T> FromTorr(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.TorrToPascals)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Pressure unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Capacitance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Capacitance.g.cs
@@ -28,6 +28,27 @@ public record Capacitance<T> : PhysicalQuantity<Capacitance<T>, T>, IVector0<Cap
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Capacitance<T> FromFarads(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Capacitance{T}"/> from a value in Microfarad.
+	/// </summary>
+	/// <param name="value">The value in Microfarad.</param>
+	/// <returns>A new <see cref="Capacitance{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Capacitance<T> FromMicrofarads(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Micro)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Capacitance{T}"/> from a value in Nanofarad.
+	/// </summary>
+	/// <param name="value">The value in Nanofarad.</param>
+	/// <returns>A new <see cref="Capacitance{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Capacitance<T> FromNanofarads(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Capacitance{T}"/> from a value in Picofarad.
+	/// </summary>
+	/// <param name="value">The value in Picofarad.</param>
+	/// <returns>A new <see cref="Capacitance{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Capacitance<T> FromPicofarads(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Pico)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-ElectricCapacitance unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Capacity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Capacity.g.cs
@@ -43,12 +43,61 @@ public record Capacity<T> : PhysicalQuantity<Capacity<T>, T>, IVector0<Capacity<
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Capacity<T> FromMilliliters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
+	/// Creates a new Capacity from a value in CubicCentimeter.
+	/// </summary>
+	/// <param name="value">The value in CubicCentimeter.</param>
+	/// <returns>A new Capacity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Capacity<T> FromCubicCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CubicCentimeterToCubicMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new Capacity from a value in CubicFoot.
+	/// </summary>
+	/// <param name="value">The value in CubicFoot.</param>
+	/// <returns>A new Capacity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Capacity<T> FromCubicFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CubicFootToCubicMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new Capacity from a value in CubicInch.
+	/// </summary>
+	/// <param name="value">The value in CubicInch.</param>
+	/// <returns>A new Capacity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Capacity<T> FromCubicInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CubicInchToCubicMeters)), nameof(value)));
+/// <summary>
 	/// Creates a new Capacity from a value in Gallon.
 	/// </summary>
 	/// <param name="value">The value in Gallon.</param>
 	/// <returns>A new Capacity instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Capacity<T> FromGallons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GallonToCubicMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new Capacity from a value in ImperialGallon.
+	/// </summary>
+	/// <param name="value">The value in ImperialGallon.</param>
+	/// <returns>A new Capacity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Capacity<T> FromImperialGallons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ImperialGallonToCubicMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new Capacity from a value in USQuart.
+	/// </summary>
+	/// <param name="value">The value in USQuart.</param>
+	/// <returns>A new Capacity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Capacity<T> FromUSQuarts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.USQuartToCubicMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new Capacity from a value in USPint.
+	/// </summary>
+	/// <param name="value">The value in USPint.</param>
+	/// <returns>A new Capacity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Capacity<T> FromUSPints(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.USPintToCubicMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new Capacity from a value in USFluidOunce.
+	/// </summary>
+	/// <param name="value">The value in USFluidOunce.</param>
+	/// <returns>A new Capacity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Capacity<T> FromUSFluidOunces(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.USFluidOunceToCubicMeters)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Volume unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CatalyticActivity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CatalyticActivity.g.cs
@@ -28,6 +28,13 @@ public record CatalyticActivity<T> : PhysicalQuantity<CatalyticActivity<T>, T>, 
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static CatalyticActivity<T> FromKatals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="CatalyticActivity{T}"/> from a value in EnzymeUnit.
+	/// </summary>
+	/// <param name="value">The value in EnzymeUnit.</param>
+	/// <returns>A new <see cref="CatalyticActivity{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static CatalyticActivity<T> FromEnzymeUnits(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.EnzymeUnitToKatals)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-CatalyticActivity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Charge.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Charge.g.cs
@@ -27,6 +27,12 @@ public record Charge<T> : PhysicalQuantity<Charge<T>, T>, IVector1<Charge<T>, T>
 	/// <returns>A new <see cref="Charge{T}"/> instance.</returns>
 	public static Charge<T> FromCoulombs(T value) => Create(value);
 /// <summary>
+	/// Creates a new <see cref="Charge{T}"/> from a value in AmpereHour.
+	/// </summary>
+	/// <param name="value">The value in AmpereHour.</param>
+	/// <returns>A new <see cref="Charge{T}"/> instance.</returns>
+	public static Charge<T> FromAmpereHours(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.AmpereHourToCoulombs)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-ElectricCharge unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ChargeMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ChargeMagnitude.g.cs
@@ -28,6 +28,13 @@ public record ChargeMagnitude<T> : PhysicalQuantity<ChargeMagnitude<T>, T>, IVec
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static ChargeMagnitude<T> FromCoulombs(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="ChargeMagnitude{T}"/> from a value in AmpereHour.
+	/// </summary>
+	/// <param name="value">The value in AmpereHour.</param>
+	/// <returns>A new <see cref="ChargeMagnitude{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ChargeMagnitude<T> FromAmpereHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AmpereHourToCoulombs)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-ElectricCharge unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ClockSpeed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ClockSpeed.g.cs
@@ -29,6 +29,20 @@ public record ClockSpeed<T> : PhysicalQuantity<ClockSpeed<T>, T>, IVector0<Clock
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static ClockSpeed<T> FromHertz(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new ClockSpeed from a value in Kilohertz.
+	/// </summary>
+	/// <param name="value">The value in Kilohertz.</param>
+	/// <returns>A new ClockSpeed instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ClockSpeed<T> FromKilohertz(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new ClockSpeed from a value in Megahertz.
+	/// </summary>
+	/// <param name="value">The value in Megahertz.</param>
+	/// <returns>A new ClockSpeed instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ClockSpeed<T> FromMegahertz(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Mega)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Frequency unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Concentration.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Concentration.g.cs
@@ -28,6 +28,20 @@ public record Concentration<T> : PhysicalQuantity<Concentration<T>, T>, IVector0
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Concentration<T> FromMolars(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Concentration{T}"/> from a value in Millimolar.
+	/// </summary>
+	/// <param name="value">The value in Millimolar.</param>
+	/// <returns>A new <see cref="Concentration{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Concentration<T> FromMillimolars(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MillimolarToMolePerCubicMeter)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Concentration{T}"/> from a value in Micromolar.
+	/// </summary>
+	/// <param name="value">The value in Micromolar.</param>
+	/// <returns>A new <see cref="Concentration{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Concentration<T> FromMicromolars(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MicromolarToMolePerCubicMeter)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Concentration unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CrossSectionalArea.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CrossSectionalArea.g.cs
@@ -29,6 +29,20 @@ public record CrossSectionalArea<T> : PhysicalQuantity<CrossSectionalArea<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static CrossSectionalArea<T> FromSquareMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new CrossSectionalArea from a value in SquareKilometer.
+	/// </summary>
+	/// <param name="value">The value in SquareKilometer.</param>
+	/// <returns>A new CrossSectionalArea instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static CrossSectionalArea<T> FromSquareKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareKilometerToSquareMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new CrossSectionalArea from a value in SquareCentimeter.
+	/// </summary>
+	/// <param name="value">The value in SquareCentimeter.</param>
+	/// <returns>A new CrossSectionalArea instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static CrossSectionalArea<T> FromSquareCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareCentimeterToSquareMeters)), nameof(value)));
+/// <summary>
 	/// Creates a new CrossSectionalArea from a value in SquareFoot.
 	/// </summary>
 	/// <param name="value">The value in SquareFoot.</param>
@@ -42,6 +56,27 @@ public record CrossSectionalArea<T> : PhysicalQuantity<CrossSectionalArea<T>, T>
 	/// <returns>A new CrossSectionalArea instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static CrossSectionalArea<T> FromSquareInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareInchToSquareMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new CrossSectionalArea from a value in SquareMile.
+	/// </summary>
+	/// <param name="value">The value in SquareMile.</param>
+	/// <returns>A new CrossSectionalArea instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static CrossSectionalArea<T> FromSquareMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareMileToSquareMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new CrossSectionalArea from a value in Hectare.
+	/// </summary>
+	/// <param name="value">The value in Hectare.</param>
+	/// <returns>A new CrossSectionalArea instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static CrossSectionalArea<T> FromHectares(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HectareToSquareMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new CrossSectionalArea from a value in Acre.
+	/// </summary>
+	/// <param name="value">The value in Acre.</param>
+	/// <returns>A new CrossSectionalArea instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static CrossSectionalArea<T> FromAcres(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AcreToSquareMeters)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Area unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Current1D.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Current1D.g.cs
@@ -27,6 +27,18 @@ public record Current1D<T> : PhysicalQuantity<Current1D<T>, T>, IVector1<Current
 	/// <returns>A new <see cref="Current1D{T}"/> instance.</returns>
 	public static Current1D<T> FromAmperes(T value) => Create(value);
 /// <summary>
+	/// Creates a new <see cref="Current1D{T}"/> from a value in Milliampere.
+	/// </summary>
+	/// <param name="value">The value in Milliampere.</param>
+	/// <returns>A new <see cref="Current1D{T}"/> instance.</returns>
+	public static Current1D<T> FromMilliamperes(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Milli)));
+/// <summary>
+	/// Creates a new <see cref="Current1D{T}"/> from a value in Kiloampere.
+	/// </summary>
+	/// <param name="value">The value in Kiloampere.</param>
+	/// <returns>A new <see cref="Current1D{T}"/> instance.</returns>
+	public static Current1D<T> FromKiloamperes(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Kilo)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-ElectricCurrent unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CurrentMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/CurrentMagnitude.g.cs
@@ -28,6 +28,20 @@ public record CurrentMagnitude<T> : PhysicalQuantity<CurrentMagnitude<T>, T>, IV
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static CurrentMagnitude<T> FromAmperes(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="CurrentMagnitude{T}"/> from a value in Milliampere.
+	/// </summary>
+	/// <param name="value">The value in Milliampere.</param>
+	/// <returns>A new <see cref="CurrentMagnitude{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static CurrentMagnitude<T> FromMilliamperes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="CurrentMagnitude{T}"/> from a value in Kiloampere.
+	/// </summary>
+	/// <param name="value">The value in Kiloampere.</param>
+	/// <returns>A new <see cref="CurrentMagnitude{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static CurrentMagnitude<T> FromKiloamperes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-ElectricCurrent unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/DecayTime.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/DecayTime.g.cs
@@ -71,6 +71,20 @@ public record DecayTime<T> : PhysicalQuantity<DecayTime<T>, T>, IVector0<DecayTi
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static DecayTime<T> FromYears(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>
+	/// Creates a new DecayTime from a value in Week.
+	/// </summary>
+	/// <param name="value">The value in Week.</param>
+	/// <returns>A new DecayTime instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static DecayTime<T> FromWeeks(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.WeekToSeconds)), nameof(value)));
+/// <summary>
+	/// Creates a new DecayTime from a value in Nanosecond.
+	/// </summary>
+	/// <param name="value">The value in Nanosecond.</param>
+	/// <returns>A new DecayTime instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static DecayTime<T> FromNanoseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Time unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Density.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Density.g.cs
@@ -28,6 +28,20 @@ public record Density<T> : PhysicalQuantity<Density<T>, T>, IVector0<Density<T>,
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Density<T> FromKilogramPerCubicMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Density{T}"/> from a value in GramPerCubicCentimeter.
+	/// </summary>
+	/// <param name="value">The value in GramPerCubicCentimeter.</param>
+	/// <returns>A new <see cref="Density{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Density<T> FromGramPerCubicCentimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GramPerCubicCentimeterToKilogramPerCubicMeter)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Density{T}"/> from a value in GramPerLiter.
+	/// </summary>
+	/// <param name="value">The value in GramPerLiter.</param>
+	/// <returns>A new <see cref="Density{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Density<T> FromGramPerLiter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GramPerLiterToKilogramPerCubicMeter)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Density unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Depth.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Depth.g.cs
@@ -99,6 +99,13 @@ public record Depth<T> : PhysicalQuantity<Depth<T>, T>, IVector0<Depth<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Depth<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>
+	/// Creates a new Depth from a value in NauticalMile.
+	/// </summary>
+	/// <param name="value">The value in NauticalMile.</param>
+	/// <returns>A new Depth instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Depth<T> FromNauticalMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.NauticalMileToMeters)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Length unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Diameter.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Diameter.g.cs
@@ -99,6 +99,13 @@ public record Diameter<T> : PhysicalQuantity<Diameter<T>, T>, IVector0<Diameter<
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Diameter<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>
+	/// Creates a new Diameter from a value in NauticalMile.
+	/// </summary>
+	/// <param name="value">The value in NauticalMile.</param>
+	/// <returns>A new Diameter instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Diameter<T> FromNauticalMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.NauticalMileToMeters)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Length unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Displacement1D.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Displacement1D.g.cs
@@ -87,6 +87,12 @@ public record Displacement1D<T> : PhysicalQuantity<Displacement1D<T>, T>, IVecto
 	/// <returns>A new <see cref="Displacement1D{T}"/> instance.</returns>
 	public static Displacement1D<T> FromMiles(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)));
 /// <summary>
+	/// Creates a new <see cref="Displacement1D{T}"/> from a value in NauticalMile.
+	/// </summary>
+	/// <param name="value">The value in NauticalMile.</param>
+	/// <returns>A new <see cref="Displacement1D{T}"/> instance.</returns>
+	public static Displacement1D<T> FromNauticalMiles(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.NauticalMileToMeters)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Length unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Distance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Distance.g.cs
@@ -99,6 +99,13 @@ public record Distance<T> : PhysicalQuantity<Distance<T>, T>, IVector0<Distance<
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Distance<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>
+	/// Creates a new Distance from a value in NauticalMile.
+	/// </summary>
+	/// <param name="value">The value in NauticalMile.</param>
+	/// <returns>A new Distance instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Distance<T> FromNauticalMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.NauticalMileToMeters)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Length unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Drag.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Drag.g.cs
@@ -29,6 +29,27 @@ public record Drag<T> : PhysicalQuantity<Drag<T>, T>, IVector0<Drag<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Drag<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new Drag from a value in Kilonewton.
+	/// </summary>
+	/// <param name="value">The value in Kilonewton.</param>
+	/// <returns>A new Drag instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Drag<T> FromKilonewtons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new Drag from a value in Dyne.
+	/// </summary>
+	/// <param name="value">The value in Dyne.</param>
+	/// <returns>A new Drag instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Drag<T> FromDynes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DyneToNewtons)), nameof(value)));
+/// <summary>
+	/// Creates a new Drag from a value in PoundForce.
+	/// </summary>
+	/// <param name="value">The value in PoundForce.</param>
+	/// <returns>A new Drag instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Drag<T> FromPoundsForce(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundForceToNewtons)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Force unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Duration.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Duration.g.cs
@@ -70,6 +70,20 @@ public record Duration<T> : PhysicalQuantity<Duration<T>, T>, IVector0<Duration<
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Duration<T> FromYears(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Duration{T}"/> from a value in Week.
+	/// </summary>
+	/// <param name="value">The value in Week.</param>
+	/// <returns>A new <see cref="Duration{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Duration<T> FromWeeks(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.WeekToSeconds)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Duration{T}"/> from a value in Nanosecond.
+	/// </summary>
+	/// <param name="value">The value in Nanosecond.</param>
+	/// <returns>A new <see cref="Duration{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Duration<T> FromNanoseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Time unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/DynamicViscosity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/DynamicViscosity.g.cs
@@ -35,6 +35,13 @@ public record DynamicViscosity<T> : PhysicalQuantity<DynamicViscosity<T>, T>, IV
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static DynamicViscosity<T> FromPoise(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoiseToPascalSecond)), nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="DynamicViscosity{T}"/> from a value in Centipoise.
+	/// </summary>
+	/// <param name="value">The value in Centipoise.</param>
+	/// <returns>A new <see cref="DynamicViscosity{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static DynamicViscosity<T> FromCentipoise(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CentipoiseToPascalSecond)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-DynamicViscosity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EMF.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EMF.g.cs
@@ -29,6 +29,13 @@ public record EMF<T> : PhysicalQuantity<EMF<T>, T>, IVector0<EMF<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static EMF<T> FromVolts(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new EMF from a value in Kilovolt.
+	/// </summary>
+	/// <param name="value">The value in Kilovolt.</param>
+	/// <returns>A new EMF instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static EMF<T> FromKilovolts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-ElectricPotential unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Energy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Energy.g.cs
@@ -28,6 +28,13 @@ public record Energy<T> : PhysicalQuantity<Energy<T>, T>, IVector0<Energy<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Energy<T> FromJoules(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Energy{T}"/> from a value in Kilojoule.
+	/// </summary>
+	/// <param name="value">The value in Kilojoule.</param>
+	/// <returns>A new <see cref="Energy{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Energy<T> FromKilojoules(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Creates a new <see cref="Energy{T}"/> from a value in ElectronVolt.
 	/// </summary>
 	/// <param name="value">The value in ElectronVolt.</param>
@@ -42,12 +49,40 @@ public record Energy<T> : PhysicalQuantity<Energy<T>, T>, IVector0<Energy<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Energy<T> FromCalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Energy{T}"/> from a value in Kilocalorie.
+	/// </summary>
+	/// <param name="value">The value in Kilocalorie.</param>
+	/// <returns>A new <see cref="Energy{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Energy<T> FromKilocalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilocalorieToJoules)), nameof(value)));
+/// <summary>
 	/// Creates a new <see cref="Energy{T}"/> from a value in KilowattHour.
 	/// </summary>
 	/// <param name="value">The value in KilowattHour.</param>
 	/// <returns>A new <see cref="Energy{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Energy<T> FromKilowattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Energy{T}"/> from a value in WattHour.
+	/// </summary>
+	/// <param name="value">The value in WattHour.</param>
+	/// <returns>A new <see cref="Energy{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Energy<T> FromWattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.WattHourToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Energy{T}"/> from a value in Erg.
+	/// </summary>
+	/// <param name="value">The value in Erg.</param>
+	/// <returns>A new <see cref="Energy{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Energy<T> FromErgs(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ErgToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Energy{T}"/> from a value in Btu.
+	/// </summary>
+	/// <param name="value">The value in Btu.</param>
+	/// <returns>A new <see cref="Energy{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Energy<T> FromBtus(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BtuToJoules)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Energy unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EnzymeActivity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EnzymeActivity.g.cs
@@ -29,6 +29,13 @@ public record EnzymeActivity<T> : PhysicalQuantity<EnzymeActivity<T>, T>, IVecto
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static EnzymeActivity<T> FromKatals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new EnzymeActivity from a value in EnzymeUnit.
+	/// </summary>
+	/// <param name="value">The value in EnzymeUnit.</param>
+	/// <returns>A new EnzymeActivity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static EnzymeActivity<T> FromEnzymeUnits(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.EnzymeUnitToKatals)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-CatalyticActivity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EquivalentDose.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/EquivalentDose.g.cs
@@ -28,6 +28,13 @@ public record EquivalentDose<T> : PhysicalQuantity<EquivalentDose<T>, T>, IVecto
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static EquivalentDose<T> FromSieverts(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="EquivalentDose{T}"/> from a value in Rem.
+	/// </summary>
+	/// <param name="value">The value in Rem.</param>
+	/// <returns>A new <see cref="EquivalentDose{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static EquivalentDose<T> FromRems(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.RemToSieverts)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-EquivalentDose unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Exposure.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Exposure.g.cs
@@ -28,6 +28,13 @@ public record Exposure<T> : PhysicalQuantity<Exposure<T>, T>, IVector0<Exposure<
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Exposure<T> FromCoulombPerKilogram(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Exposure{T}"/> from a value in Roentgen.
+	/// </summary>
+	/// <param name="value">The value in Roentgen.</param>
+	/// <returns>A new <see cref="Exposure{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Exposure<T> FromRoentgens(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.RoentgenToCoulombsPerKilogram)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Exposure unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/FieldOfView.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/FieldOfView.g.cs
@@ -36,6 +36,27 @@ public record FieldOfView<T> : PhysicalQuantity<FieldOfView<T>, T>, IVector0<Fie
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static FieldOfView<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>
+	/// Creates a new FieldOfView from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new FieldOfView instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static FieldOfView<T> FromGradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new FieldOfView from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new FieldOfView instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static FieldOfView<T> FromRevolutions(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new FieldOfView from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new FieldOfView instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static FieldOfView<T> FromMilliradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-AngularDisplacement unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/FlowSpeed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/FlowSpeed.g.cs
@@ -43,6 +43,20 @@ public record FlowSpeed<T> : PhysicalQuantity<FlowSpeed<T>, T>, IVector0<FlowSpe
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static FlowSpeed<T> FromMilesPerHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MilesPerHourToMetersPerSecond)), nameof(value)));
 /// <summary>
+	/// Creates a new FlowSpeed from a value in FeetPerSecond.
+	/// </summary>
+	/// <param name="value">The value in FeetPerSecond.</param>
+	/// <returns>A new FlowSpeed instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static FlowSpeed<T> FromFeetPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetPerSecondToMetersPerSecond)), nameof(value)));
+/// <summary>
+	/// Creates a new FlowSpeed from a value in Knot.
+	/// </summary>
+	/// <param name="value">The value in Knot.</param>
+	/// <returns>A new FlowSpeed instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static FlowSpeed<T> FromKnots(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KnotToMetersPerSecond)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Velocity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Force1D.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Force1D.g.cs
@@ -27,6 +27,24 @@ public record Force1D<T> : PhysicalQuantity<Force1D<T>, T>, IVector1<Force1D<T>,
 	/// <returns>A new <see cref="Force1D{T}"/> instance.</returns>
 	public static Force1D<T> FromNewtons(T value) => Create(value);
 /// <summary>
+	/// Creates a new <see cref="Force1D{T}"/> from a value in Kilonewton.
+	/// </summary>
+	/// <param name="value">The value in Kilonewton.</param>
+	/// <returns>A new <see cref="Force1D{T}"/> instance.</returns>
+	public static Force1D<T> FromKilonewtons(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Kilo)));
+/// <summary>
+	/// Creates a new <see cref="Force1D{T}"/> from a value in Dyne.
+	/// </summary>
+	/// <param name="value">The value in Dyne.</param>
+	/// <returns>A new <see cref="Force1D{T}"/> instance.</returns>
+	public static Force1D<T> FromDynes(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DyneToNewtons)));
+/// <summary>
+	/// Creates a new <see cref="Force1D{T}"/> from a value in PoundForce.
+	/// </summary>
+	/// <param name="value">The value in PoundForce.</param>
+	/// <returns>A new <see cref="Force1D{T}"/> instance.</returns>
+	public static Force1D<T> FromPoundsForce(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.PoundForceToNewtons)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Force unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ForceMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ForceMagnitude.g.cs
@@ -28,6 +28,27 @@ public record ForceMagnitude<T> : PhysicalQuantity<ForceMagnitude<T>, T>, IVecto
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static ForceMagnitude<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="ForceMagnitude{T}"/> from a value in Kilonewton.
+	/// </summary>
+	/// <param name="value">The value in Kilonewton.</param>
+	/// <returns>A new <see cref="ForceMagnitude{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ForceMagnitude<T> FromKilonewtons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="ForceMagnitude{T}"/> from a value in Dyne.
+	/// </summary>
+	/// <param name="value">The value in Dyne.</param>
+	/// <returns>A new <see cref="ForceMagnitude{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ForceMagnitude<T> FromDynes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DyneToNewtons)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="ForceMagnitude{T}"/> from a value in PoundForce.
+	/// </summary>
+	/// <param name="value">The value in PoundForce.</param>
+	/// <returns>A new <see cref="ForceMagnitude{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ForceMagnitude<T> FromPoundsForce(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundForceToNewtons)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Force unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Frequency.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Frequency.g.cs
@@ -28,6 +28,20 @@ public record Frequency<T> : PhysicalQuantity<Frequency<T>, T>, IVector0<Frequen
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Frequency<T> FromHertz(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Frequency{T}"/> from a value in Kilohertz.
+	/// </summary>
+	/// <param name="value">The value in Kilohertz.</param>
+	/// <returns>A new <see cref="Frequency{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Frequency<T> FromKilohertz(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Frequency{T}"/> from a value in Megahertz.
+	/// </summary>
+	/// <param name="value">The value in Megahertz.</param>
+	/// <returns>A new <see cref="Frequency{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Frequency<T> FromMegahertz(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Mega)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Frequency unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Friction.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Friction.g.cs
@@ -29,6 +29,27 @@ public record Friction<T> : PhysicalQuantity<Friction<T>, T>, IVector0<Friction<
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Friction<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new Friction from a value in Kilonewton.
+	/// </summary>
+	/// <param name="value">The value in Kilonewton.</param>
+	/// <returns>A new Friction instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Friction<T> FromKilonewtons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new Friction from a value in Dyne.
+	/// </summary>
+	/// <param name="value">The value in Dyne.</param>
+	/// <returns>A new Friction instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Friction<T> FromDynes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DyneToNewtons)), nameof(value)));
+/// <summary>
+	/// Creates a new Friction from a value in PoundForce.
+	/// </summary>
+	/// <param name="value">The value in PoundForce.</param>
+	/// <returns>A new Friction instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Friction<T> FromPoundsForce(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundForceToNewtons)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Force unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GaugePressure.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GaugePressure.g.cs
@@ -29,6 +29,13 @@ public record GaugePressure<T> : PhysicalQuantity<GaugePressure<T>, T>, IVector0
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static GaugePressure<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new GaugePressure from a value in Kilopascal.
+	/// </summary>
+	/// <param name="value">The value in Kilopascal.</param>
+	/// <returns>A new GaugePressure instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static GaugePressure<T> FromKilopascals(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Creates a new GaugePressure from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
@@ -49,6 +56,13 @@ public record GaugePressure<T> : PhysicalQuantity<GaugePressure<T>, T>, IVector0
 	/// <returns>A new GaugePressure instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static GaugePressure<T> FromPsi(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PsiToPascals)), nameof(value)));
+/// <summary>
+	/// Creates a new GaugePressure from a value in Torr.
+	/// </summary>
+	/// <param name="value">The value in Torr.</param>
+	/// <returns>A new GaugePressure instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static GaugePressure<T> FromTorr(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.TorrToPascals)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Pressure unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GravitationalAcceleration.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GravitationalAcceleration.g.cs
@@ -29,6 +29,13 @@ public record GravitationalAcceleration<T> : PhysicalQuantity<GravitationalAccel
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static GravitationalAcceleration<T> FromMetersPerSecondSquared(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new GravitationalAcceleration from a value in StandardGravity.
+	/// </summary>
+	/// <param name="value">The value in StandardGravity.</param>
+	/// <returns>A new GravitationalAcceleration instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static GravitationalAcceleration<T> FromStandardGravity(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.StandardGravityToMetersPerSecondSquared)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Acceleration unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GroundSpeed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GroundSpeed.g.cs
@@ -43,6 +43,20 @@ public record GroundSpeed<T> : PhysicalQuantity<GroundSpeed<T>, T>, IVector0<Gro
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static GroundSpeed<T> FromMilesPerHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MilesPerHourToMetersPerSecond)), nameof(value)));
 /// <summary>
+	/// Creates a new GroundSpeed from a value in FeetPerSecond.
+	/// </summary>
+	/// <param name="value">The value in FeetPerSecond.</param>
+	/// <returns>A new GroundSpeed instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static GroundSpeed<T> FromFeetPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetPerSecondToMetersPerSecond)), nameof(value)));
+/// <summary>
+	/// Creates a new GroundSpeed from a value in Knot.
+	/// </summary>
+	/// <param name="value">The value in Knot.</param>
+	/// <returns>A new GroundSpeed instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static GroundSpeed<T> FromKnots(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KnotToMetersPerSecond)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Velocity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GroupVelocity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/GroupVelocity.g.cs
@@ -43,6 +43,20 @@ public record GroupVelocity<T> : PhysicalQuantity<GroupVelocity<T>, T>, IVector0
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static GroupVelocity<T> FromMilesPerHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MilesPerHourToMetersPerSecond)), nameof(value)));
 /// <summary>
+	/// Creates a new GroupVelocity from a value in FeetPerSecond.
+	/// </summary>
+	/// <param name="value">The value in FeetPerSecond.</param>
+	/// <returns>A new GroupVelocity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static GroupVelocity<T> FromFeetPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetPerSecondToMetersPerSecond)), nameof(value)));
+/// <summary>
+	/// Creates a new GroupVelocity from a value in Knot.
+	/// </summary>
+	/// <param name="value">The value in Knot.</param>
+	/// <returns>A new GroupVelocity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static GroupVelocity<T> FromKnots(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KnotToMetersPerSecond)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Velocity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HalfLife.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HalfLife.g.cs
@@ -71,6 +71,20 @@ public record HalfLife<T> : PhysicalQuantity<HalfLife<T>, T>, IVector0<HalfLife<
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static HalfLife<T> FromYears(T value) => Create(Vector0Guards.EnsurePositive((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>
+	/// Creates a new HalfLife from a value in Week.
+	/// </summary>
+	/// <param name="value">The value in Week.</param>
+	/// <returns>A new HalfLife instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static HalfLife<T> FromWeeks(T value) => Create(Vector0Guards.EnsurePositive((value * T.CreateChecked(Units.ConversionConstants.WeekToSeconds)), nameof(value)));
+/// <summary>
+	/// Creates a new HalfLife from a value in Nanosecond.
+	/// </summary>
+	/// <param name="value">The value in Nanosecond.</param>
+	/// <returns>A new HalfLife instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static HalfLife<T> FromNanoseconds(T value) => Create(Vector0Guards.EnsurePositive((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Time unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Heading.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Heading.g.cs
@@ -34,6 +34,24 @@ public record Heading<T> : PhysicalQuantity<Heading<T>, T>, IVector1<Heading<T>,
 	/// <returns>A new Heading instance.</returns>
 	public static Heading<T> FromDegrees(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
 /// <summary>
+	/// Creates a new Heading from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new Heading instance.</returns>
+	public static Heading<T> FromGradians(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)));
+/// <summary>
+	/// Creates a new Heading from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new Heading instance.</returns>
+	public static Heading<T> FromRevolutions(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)));
+/// <summary>
+	/// Creates a new Heading from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new Heading instance.</returns>
+	public static Heading<T> FromMilliradians(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Milli)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-AngularDisplacement unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Heat.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Heat.g.cs
@@ -29,6 +29,13 @@ public record Heat<T> : PhysicalQuantity<Heat<T>, T>, IVector0<Heat<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Heat<T> FromJoules(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new Heat from a value in Kilojoule.
+	/// </summary>
+	/// <param name="value">The value in Kilojoule.</param>
+	/// <returns>A new Heat instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Heat<T> FromKilojoules(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Creates a new Heat from a value in ElectronVolt.
 	/// </summary>
 	/// <param name="value">The value in ElectronVolt.</param>
@@ -43,12 +50,40 @@ public record Heat<T> : PhysicalQuantity<Heat<T>, T>, IVector0<Heat<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Heat<T> FromCalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
 /// <summary>
+	/// Creates a new Heat from a value in Kilocalorie.
+	/// </summary>
+	/// <param name="value">The value in Kilocalorie.</param>
+	/// <returns>A new Heat instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Heat<T> FromKilocalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilocalorieToJoules)), nameof(value)));
+/// <summary>
 	/// Creates a new Heat from a value in KilowattHour.
 	/// </summary>
 	/// <param name="value">The value in KilowattHour.</param>
 	/// <returns>A new Heat instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Heat<T> FromKilowattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new Heat from a value in WattHour.
+	/// </summary>
+	/// <param name="value">The value in WattHour.</param>
+	/// <returns>A new Heat instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Heat<T> FromWattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.WattHourToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new Heat from a value in Erg.
+	/// </summary>
+	/// <param name="value">The value in Erg.</param>
+	/// <returns>A new Heat instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Heat<T> FromErgs(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ErgToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new Heat from a value in Btu.
+	/// </summary>
+	/// <param name="value">The value in Btu.</param>
+	/// <returns>A new Heat instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Heat<T> FromBtus(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BtuToJoules)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Energy unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HeatFlowRate.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/HeatFlowRate.g.cs
@@ -29,6 +29,20 @@ public record HeatFlowRate<T> : PhysicalQuantity<HeatFlowRate<T>, T>, IVector0<H
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static HeatFlowRate<T> FromWatts(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new HeatFlowRate from a value in Kilowatt.
+	/// </summary>
+	/// <param name="value">The value in Kilowatt.</param>
+	/// <returns>A new HeatFlowRate instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static HeatFlowRate<T> FromKilowatts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new HeatFlowRate from a value in Megawatt.
+	/// </summary>
+	/// <param name="value">The value in Megawatt.</param>
+	/// <returns>A new HeatFlowRate instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static HeatFlowRate<T> FromMegawatts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Mega)), nameof(value)));
+/// <summary>
 	/// Creates a new HeatFlowRate from a value in Horsepower.
 	/// </summary>
 	/// <param name="value">The value in Horsepower.</param>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Height.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Height.g.cs
@@ -99,6 +99,13 @@ public record Height<T> : PhysicalQuantity<Height<T>, T>, IVector0<Height<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Height<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>
+	/// Creates a new Height from a value in NauticalMile.
+	/// </summary>
+	/// <param name="value">The value in NauticalMile.</param>
+	/// <returns>A new Height instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Height<T> FromNauticalMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.NauticalMileToMeters)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Length unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Illuminance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Illuminance.g.cs
@@ -28,6 +28,13 @@ public record Illuminance<T> : PhysicalQuantity<Illuminance<T>, T>, IVector0<Ill
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Illuminance<T> FromLux(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Illuminance{T}"/> from a value in FootCandle.
+	/// </summary>
+	/// <param name="value">The value in FootCandle.</param>
+	/// <returns>A new <see cref="Illuminance{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Illuminance<T> FromFootCandles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FootCandleToLux)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Illuminance unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/KineticEnergy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/KineticEnergy.g.cs
@@ -29,6 +29,13 @@ public record KineticEnergy<T> : PhysicalQuantity<KineticEnergy<T>, T>, IVector0
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static KineticEnergy<T> FromJoules(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new KineticEnergy from a value in Kilojoule.
+	/// </summary>
+	/// <param name="value">The value in Kilojoule.</param>
+	/// <returns>A new KineticEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static KineticEnergy<T> FromKilojoules(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Creates a new KineticEnergy from a value in ElectronVolt.
 	/// </summary>
 	/// <param name="value">The value in ElectronVolt.</param>
@@ -43,12 +50,40 @@ public record KineticEnergy<T> : PhysicalQuantity<KineticEnergy<T>, T>, IVector0
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static KineticEnergy<T> FromCalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
 /// <summary>
+	/// Creates a new KineticEnergy from a value in Kilocalorie.
+	/// </summary>
+	/// <param name="value">The value in Kilocalorie.</param>
+	/// <returns>A new KineticEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static KineticEnergy<T> FromKilocalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilocalorieToJoules)), nameof(value)));
+/// <summary>
 	/// Creates a new KineticEnergy from a value in KilowattHour.
 	/// </summary>
 	/// <param name="value">The value in KilowattHour.</param>
 	/// <returns>A new KineticEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static KineticEnergy<T> FromKilowattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new KineticEnergy from a value in WattHour.
+	/// </summary>
+	/// <param name="value">The value in WattHour.</param>
+	/// <returns>A new KineticEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static KineticEnergy<T> FromWattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.WattHourToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new KineticEnergy from a value in Erg.
+	/// </summary>
+	/// <param name="value">The value in Erg.</param>
+	/// <returns>A new KineticEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static KineticEnergy<T> FromErgs(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ErgToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new KineticEnergy from a value in Btu.
+	/// </summary>
+	/// <param name="value">The value in Btu.</param>
+	/// <returns>A new KineticEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static KineticEnergy<T> FromBtus(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BtuToJoules)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Energy unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Latency.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Latency.g.cs
@@ -71,6 +71,20 @@ public record Latency<T> : PhysicalQuantity<Latency<T>, T>, IVector0<Latency<T>,
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Latency<T> FromYears(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>
+	/// Creates a new Latency from a value in Week.
+	/// </summary>
+	/// <param name="value">The value in Week.</param>
+	/// <returns>A new Latency instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Latency<T> FromWeeks(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.WeekToSeconds)), nameof(value)));
+/// <summary>
+	/// Creates a new Latency from a value in Nanosecond.
+	/// </summary>
+	/// <param name="value">The value in Nanosecond.</param>
+	/// <returns>A new Latency instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Latency<T> FromNanoseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Time unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Length.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Length.g.cs
@@ -98,6 +98,13 @@ public record Length<T> : PhysicalQuantity<Length<T>, T>, IVector0<Length<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Length<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Length{T}"/> from a value in NauticalMile.
+	/// </summary>
+	/// <param name="value">The value in NauticalMile.</param>
+	/// <returns>A new <see cref="Length{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Length<T> FromNauticalMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.NauticalMileToMeters)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Length unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Lift.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Lift.g.cs
@@ -29,6 +29,27 @@ public record Lift<T> : PhysicalQuantity<Lift<T>, T>, IVector0<Lift<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Lift<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new Lift from a value in Kilonewton.
+	/// </summary>
+	/// <param name="value">The value in Kilonewton.</param>
+	/// <returns>A new Lift instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Lift<T> FromKilonewtons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new Lift from a value in Dyne.
+	/// </summary>
+	/// <param name="value">The value in Dyne.</param>
+	/// <returns>A new Lift instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Lift<T> FromDynes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DyneToNewtons)), nameof(value)));
+/// <summary>
+	/// Creates a new Lift from a value in PoundForce.
+	/// </summary>
+	/// <param name="value">The value in PoundForce.</param>
+	/// <returns>A new Lift instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Lift<T> FromPoundsForce(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundForceToNewtons)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Force unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Luminance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Luminance.g.cs
@@ -29,6 +29,13 @@ public record Luminance<T> : PhysicalQuantity<Luminance<T>, T>, IVector0<Luminan
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Luminance<T> FromLux(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new Luminance from a value in FootCandle.
+	/// </summary>
+	/// <param name="value">The value in FootCandle.</param>
+	/// <returns>A new Luminance instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Luminance<T> FromFootCandles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FootCandleToLux)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Illuminance unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/LuminousIntensity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/LuminousIntensity.g.cs
@@ -28,6 +28,13 @@ public record LuminousIntensity<T> : PhysicalQuantity<LuminousIntensity<T>, T>, 
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static LuminousIntensity<T> FromCandelas(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="LuminousIntensity{T}"/> from a value in Millicandela.
+	/// </summary>
+	/// <param name="value">The value in Millicandela.</param>
+	/// <returns>A new <see cref="LuminousIntensity{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static LuminousIntensity<T> FromMillicandelas(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-LuminousIntensity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MachNumber.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MachNumber.g.cs
@@ -43,6 +43,48 @@ public record MachNumber<T> : PhysicalQuantity<MachNumber<T>, T>, IVector0<MachN
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static MachNumber<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>
+	/// Creates a new MachNumber from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new MachNumber instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MachNumber<T> FromGradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new MachNumber from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new MachNumber instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MachNumber<T> FromRevolutions(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new MachNumber from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new MachNumber instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MachNumber<T> FromMilliradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+/// <summary>
+	/// Creates a new MachNumber from a value in PartsPerMillion.
+	/// </summary>
+	/// <param name="value">The value in PartsPerMillion.</param>
+	/// <returns>A new MachNumber instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MachNumber<T> FromPartsPerMillion(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PartsPerMillionToRatio)), nameof(value)));
+/// <summary>
+	/// Creates a new MachNumber from a value in PartsPerBillion.
+	/// </summary>
+	/// <param name="value">The value in PartsPerBillion.</param>
+	/// <returns>A new MachNumber instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MachNumber<T> FromPartsPerBillion(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PartsPerBillionToRatio)), nameof(value)));
+/// <summary>
+	/// Creates a new MachNumber from a value in PercentByWeight.
+	/// </summary>
+	/// <param name="value">The value in PercentByWeight.</param>
+	/// <returns>A new MachNumber instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MachNumber<T> FromPercentByWeight(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PercentByWeightToRatio)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Dimensionless unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Mass.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Mass.g.cs
@@ -56,6 +56,27 @@ public record Mass<T> : PhysicalQuantity<Mass<T>, T>, IVector0<Mass<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Mass<T> FromOunces(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.OunceToKilograms)), nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Mass{T}"/> from a value in Stone.
+	/// </summary>
+	/// <param name="value">The value in Stone.</param>
+	/// <returns>A new <see cref="Mass{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Mass<T> FromStone(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.StoneToKilograms)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Mass{T}"/> from a value in ShortTon.
+	/// </summary>
+	/// <param name="value">The value in ShortTon.</param>
+	/// <returns>A new <see cref="Mass{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Mass<T> FromShortTons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ShortTonToKilograms)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Mass{T}"/> from a value in AtomicMassUnit.
+	/// </summary>
+	/// <param name="value">The value in AtomicMassUnit.</param>
+	/// <returns>A new <see cref="Mass{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Mass<T> FromAtomicMassUnits(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AtomicMassUnitToKilograms)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Mass unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MolarEnergy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MolarEnergy.g.cs
@@ -35,6 +35,13 @@ public record MolarEnergy<T> : PhysicalQuantity<MolarEnergy<T>, T>, IVector0<Mol
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static MolarEnergy<T> FromKilojoulePerMole(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilojoulePerMoleToJoulePerMole)), nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="MolarEnergy{T}"/> from a value in CaloriePerMole.
+	/// </summary>
+	/// <param name="value">The value in CaloriePerMole.</param>
+	/// <returns>A new <see cref="MolarEnergy{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MolarEnergy<T> FromCaloriesPerMole(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CaloriePerMoleToJoulePerMole)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-MolarEnergy unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MolarEnthalpy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MolarEnthalpy.g.cs
@@ -36,6 +36,13 @@ public record MolarEnthalpy<T> : PhysicalQuantity<MolarEnthalpy<T>, T>, IVector0
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static MolarEnthalpy<T> FromKilojoulePerMole(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilojoulePerMoleToJoulePerMole)), nameof(value)));
 /// <summary>
+	/// Creates a new MolarEnthalpy from a value in CaloriePerMole.
+	/// </summary>
+	/// <param name="value">The value in CaloriePerMole.</param>
+	/// <returns>A new MolarEnthalpy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MolarEnthalpy<T> FromCaloriesPerMole(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CaloriePerMoleToJoulePerMole)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-MolarEnergy unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MolarMass.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/MolarMass.g.cs
@@ -35,6 +35,13 @@ public record MolarMass<T> : PhysicalQuantity<MolarMass<T>, T>, IVector0<MolarMa
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static MolarMass<T> FromGramPerMole(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GramPerMoleToKilogramPerMole)), nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="MolarMass{T}"/> from a value in Dalton.
+	/// </summary>
+	/// <param name="value">The value in Dalton.</param>
+	/// <returns>A new <see cref="MolarMass{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static MolarMass<T> FromDaltons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GramPerMoleToKilogramPerMole)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-MolarMass unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/NormalForce.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/NormalForce.g.cs
@@ -29,6 +29,27 @@ public record NormalForce<T> : PhysicalQuantity<NormalForce<T>, T>, IVector0<Nor
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static NormalForce<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new NormalForce from a value in Kilonewton.
+	/// </summary>
+	/// <param name="value">The value in Kilonewton.</param>
+	/// <returns>A new NormalForce instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static NormalForce<T> FromKilonewtons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new NormalForce from a value in Dyne.
+	/// </summary>
+	/// <param name="value">The value in Dyne.</param>
+	/// <returns>A new NormalForce instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static NormalForce<T> FromDynes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DyneToNewtons)), nameof(value)));
+/// <summary>
+	/// Creates a new NormalForce from a value in PoundForce.
+	/// </summary>
+	/// <param name="value">The value in PoundForce.</param>
+	/// <returns>A new NormalForce instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static NormalForce<T> FromPoundsForce(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundForceToNewtons)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Force unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Offset.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Offset.g.cs
@@ -88,6 +88,12 @@ public record Offset<T> : PhysicalQuantity<Offset<T>, T>, IVector1<Offset<T>, T>
 	/// <returns>A new Offset instance.</returns>
 	public static Offset<T> FromMiles(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)));
 /// <summary>
+	/// Creates a new Offset from a value in NauticalMile.
+	/// </summary>
+	/// <param name="value">The value in NauticalMile.</param>
+	/// <returns>A new Offset instance.</returns>
+	public static Offset<T> FromNauticalMiles(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.NauticalMileToMeters)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Length unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Perimeter.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Perimeter.g.cs
@@ -99,6 +99,13 @@ public record Perimeter<T> : PhysicalQuantity<Perimeter<T>, T>, IVector0<Perimet
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Perimeter<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>
+	/// Creates a new Perimeter from a value in NauticalMile.
+	/// </summary>
+	/// <param name="value">The value in NauticalMile.</param>
+	/// <returns>A new Perimeter instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Perimeter<T> FromNauticalMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.NauticalMileToMeters)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Length unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Period.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Period.g.cs
@@ -71,6 +71,20 @@ public record Period<T> : PhysicalQuantity<Period<T>, T>, IVector0<Period<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Period<T> FromYears(T value) => Create(Vector0Guards.EnsurePositive((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>
+	/// Creates a new Period from a value in Week.
+	/// </summary>
+	/// <param name="value">The value in Week.</param>
+	/// <returns>A new Period instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Period<T> FromWeeks(T value) => Create(Vector0Guards.EnsurePositive((value * T.CreateChecked(Units.ConversionConstants.WeekToSeconds)), nameof(value)));
+/// <summary>
+	/// Creates a new Period from a value in Nanosecond.
+	/// </summary>
+	/// <param name="value">The value in Nanosecond.</param>
+	/// <returns>A new Period instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Period<T> FromNanoseconds(T value) => Create(Vector0Guards.EnsurePositive((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Time unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Phase.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Phase.g.cs
@@ -34,6 +34,24 @@ public record Phase<T> : PhysicalQuantity<Phase<T>, T>, IVector1<Phase<T>, T>
 	/// <returns>A new Phase instance.</returns>
 	public static Phase<T> FromDegrees(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
 /// <summary>
+	/// Creates a new Phase from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new Phase instance.</returns>
+	public static Phase<T> FromGradians(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)));
+/// <summary>
+	/// Creates a new Phase from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new Phase instance.</returns>
+	public static Phase<T> FromRevolutions(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)));
+/// <summary>
+	/// Creates a new Phase from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new Phase instance.</returns>
+	public static Phase<T> FromMilliradians(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Milli)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-AngularDisplacement unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/PhaseVelocity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/PhaseVelocity.g.cs
@@ -43,6 +43,20 @@ public record PhaseVelocity<T> : PhysicalQuantity<PhaseVelocity<T>, T>, IVector0
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static PhaseVelocity<T> FromMilesPerHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MilesPerHourToMetersPerSecond)), nameof(value)));
 /// <summary>
+	/// Creates a new PhaseVelocity from a value in FeetPerSecond.
+	/// </summary>
+	/// <param name="value">The value in FeetPerSecond.</param>
+	/// <returns>A new PhaseVelocity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static PhaseVelocity<T> FromFeetPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetPerSecondToMetersPerSecond)), nameof(value)));
+/// <summary>
+	/// Creates a new PhaseVelocity from a value in Knot.
+	/// </summary>
+	/// <param name="value">The value in Knot.</param>
+	/// <returns>A new PhaseVelocity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static PhaseVelocity<T> FromKnots(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KnotToMetersPerSecond)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Velocity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Pitch.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Pitch.g.cs
@@ -29,6 +29,20 @@ public record Pitch<T> : PhysicalQuantity<Pitch<T>, T>, IVector0<Pitch<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Pitch<T> FromHertz(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new Pitch from a value in Kilohertz.
+	/// </summary>
+	/// <param name="value">The value in Kilohertz.</param>
+	/// <returns>A new Pitch instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Pitch<T> FromKilohertz(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new Pitch from a value in Megahertz.
+	/// </summary>
+	/// <param name="value">The value in Megahertz.</param>
+	/// <returns>A new Pitch instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Pitch<T> FromMegahertz(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Mega)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Frequency unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/PotentialEnergy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/PotentialEnergy.g.cs
@@ -29,6 +29,13 @@ public record PotentialEnergy<T> : PhysicalQuantity<PotentialEnergy<T>, T>, IVec
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static PotentialEnergy<T> FromJoules(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new PotentialEnergy from a value in Kilojoule.
+	/// </summary>
+	/// <param name="value">The value in Kilojoule.</param>
+	/// <returns>A new PotentialEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static PotentialEnergy<T> FromKilojoules(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Creates a new PotentialEnergy from a value in ElectronVolt.
 	/// </summary>
 	/// <param name="value">The value in ElectronVolt.</param>
@@ -43,12 +50,40 @@ public record PotentialEnergy<T> : PhysicalQuantity<PotentialEnergy<T>, T>, IVec
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static PotentialEnergy<T> FromCalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
 /// <summary>
+	/// Creates a new PotentialEnergy from a value in Kilocalorie.
+	/// </summary>
+	/// <param name="value">The value in Kilocalorie.</param>
+	/// <returns>A new PotentialEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static PotentialEnergy<T> FromKilocalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilocalorieToJoules)), nameof(value)));
+/// <summary>
 	/// Creates a new PotentialEnergy from a value in KilowattHour.
 	/// </summary>
 	/// <param name="value">The value in KilowattHour.</param>
 	/// <returns>A new PotentialEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static PotentialEnergy<T> FromKilowattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new PotentialEnergy from a value in WattHour.
+	/// </summary>
+	/// <param name="value">The value in WattHour.</param>
+	/// <returns>A new PotentialEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static PotentialEnergy<T> FromWattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.WattHourToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new PotentialEnergy from a value in Erg.
+	/// </summary>
+	/// <param name="value">The value in Erg.</param>
+	/// <returns>A new PotentialEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static PotentialEnergy<T> FromErgs(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ErgToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new PotentialEnergy from a value in Btu.
+	/// </summary>
+	/// <param name="value">The value in Btu.</param>
+	/// <returns>A new PotentialEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static PotentialEnergy<T> FromBtus(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BtuToJoules)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Energy unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Power.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Power.g.cs
@@ -28,6 +28,20 @@ public record Power<T> : PhysicalQuantity<Power<T>, T>, IVector0<Power<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Power<T> FromWatts(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Power{T}"/> from a value in Kilowatt.
+	/// </summary>
+	/// <param name="value">The value in Kilowatt.</param>
+	/// <returns>A new <see cref="Power{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Power<T> FromKilowatts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Power{T}"/> from a value in Megawatt.
+	/// </summary>
+	/// <param name="value">The value in Megawatt.</param>
+	/// <returns>A new <see cref="Power{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Power<T> FromMegawatts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Mega)), nameof(value)));
+/// <summary>
 	/// Creates a new <see cref="Power{T}"/> from a value in Horsepower.
 	/// </summary>
 	/// <param name="value">The value in Horsepower.</param>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Pressure.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Pressure.g.cs
@@ -28,6 +28,13 @@ public record Pressure<T> : PhysicalQuantity<Pressure<T>, T>, IVector0<Pressure<
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Pressure<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Pressure{T}"/> from a value in Kilopascal.
+	/// </summary>
+	/// <param name="value">The value in Kilopascal.</param>
+	/// <returns>A new <see cref="Pressure{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Pressure<T> FromKilopascals(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Creates a new <see cref="Pressure{T}"/> from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
@@ -48,6 +55,13 @@ public record Pressure<T> : PhysicalQuantity<Pressure<T>, T>, IVector0<Pressure<
 	/// <returns>A new <see cref="Pressure{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Pressure<T> FromPsi(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PsiToPascals)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Pressure{T}"/> from a value in Torr.
+	/// </summary>
+	/// <param name="value">The value in Torr.</param>
+	/// <returns>A new <see cref="Pressure{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Pressure<T> FromTorr(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.TorrToPascals)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Pressure unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/RadioactiveActivity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/RadioactiveActivity.g.cs
@@ -28,6 +28,13 @@ public record RadioactiveActivity<T> : PhysicalQuantity<RadioactiveActivity<T>, 
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static RadioactiveActivity<T> FromBecquerels(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="RadioactiveActivity{T}"/> from a value in Curie.
+	/// </summary>
+	/// <param name="value">The value in Curie.</param>
+	/// <returns>A new <see cref="RadioactiveActivity{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static RadioactiveActivity<T> FromCuries(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CurieToBecquerels)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-RadioactiveActivity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Radius.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Radius.g.cs
@@ -99,6 +99,13 @@ public record Radius<T> : PhysicalQuantity<Radius<T>, T>, IVector0<Radius<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Radius<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>
+	/// Creates a new Radius from a value in NauticalMile.
+	/// </summary>
+	/// <param name="value">The value in NauticalMile.</param>
+	/// <returns>A new Radius instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Radius<T> FromNauticalMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.NauticalMileToMeters)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Length unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Ratio.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Ratio.g.cs
@@ -42,6 +42,48 @@ public record Ratio<T> : PhysicalQuantity<Ratio<T>, T>, IVector0<Ratio<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Ratio<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Ratio{T}"/> from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new <see cref="Ratio{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Ratio<T> FromGradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Ratio{T}"/> from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new <see cref="Ratio{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Ratio<T> FromRevolutions(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Ratio{T}"/> from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new <see cref="Ratio{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Ratio<T> FromMilliradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Ratio{T}"/> from a value in PartsPerMillion.
+	/// </summary>
+	/// <param name="value">The value in PartsPerMillion.</param>
+	/// <returns>A new <see cref="Ratio{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Ratio<T> FromPartsPerMillion(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PartsPerMillionToRatio)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Ratio{T}"/> from a value in PartsPerBillion.
+	/// </summary>
+	/// <param name="value">The value in PartsPerBillion.</param>
+	/// <returns>A new <see cref="Ratio{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Ratio<T> FromPartsPerBillion(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PartsPerBillionToRatio)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Ratio{T}"/> from a value in PercentByWeight.
+	/// </summary>
+	/// <param name="value">The value in PercentByWeight.</param>
+	/// <returns>A new <see cref="Ratio{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Ratio<T> FromPercentByWeight(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PercentByWeightToRatio)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Dimensionless unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/RefractiveIndex.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/RefractiveIndex.g.cs
@@ -43,6 +43,48 @@ public record RefractiveIndex<T> : PhysicalQuantity<RefractiveIndex<T>, T>, IVec
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static RefractiveIndex<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>
+	/// Creates a new RefractiveIndex from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new RefractiveIndex instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static RefractiveIndex<T> FromGradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new RefractiveIndex from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new RefractiveIndex instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static RefractiveIndex<T> FromRevolutions(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new RefractiveIndex from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new RefractiveIndex instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static RefractiveIndex<T> FromMilliradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+/// <summary>
+	/// Creates a new RefractiveIndex from a value in PartsPerMillion.
+	/// </summary>
+	/// <param name="value">The value in PartsPerMillion.</param>
+	/// <returns>A new RefractiveIndex instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static RefractiveIndex<T> FromPartsPerMillion(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PartsPerMillionToRatio)), nameof(value)));
+/// <summary>
+	/// Creates a new RefractiveIndex from a value in PartsPerBillion.
+	/// </summary>
+	/// <param name="value">The value in PartsPerBillion.</param>
+	/// <returns>A new RefractiveIndex instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static RefractiveIndex<T> FromPartsPerBillion(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PartsPerBillionToRatio)), nameof(value)));
+/// <summary>
+	/// Creates a new RefractiveIndex from a value in PercentByWeight.
+	/// </summary>
+	/// <param name="value">The value in PercentByWeight.</param>
+	/// <returns>A new RefractiveIndex instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static RefractiveIndex<T> FromPercentByWeight(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PercentByWeightToRatio)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Dimensionless unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Resistance.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Resistance.g.cs
@@ -28,6 +28,20 @@ public record Resistance<T> : PhysicalQuantity<Resistance<T>, T>, IVector0<Resis
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Resistance<T> FromOhms(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Resistance{T}"/> from a value in Kilohm.
+	/// </summary>
+	/// <param name="value">The value in Kilohm.</param>
+	/// <returns>A new <see cref="Resistance{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Resistance<T> FromKilohms(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Resistance{T}"/> from a value in Megohm.
+	/// </summary>
+	/// <param name="value">The value in Megohm.</param>
+	/// <returns>A new <see cref="Resistance{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Resistance<T> FromMegohms(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Mega)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-ElectricResistance unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReverberationTime.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReverberationTime.g.cs
@@ -71,6 +71,20 @@ public record ReverberationTime<T> : PhysicalQuantity<ReverberationTime<T>, T>, 
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static ReverberationTime<T> FromYears(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>
+	/// Creates a new ReverberationTime from a value in Week.
+	/// </summary>
+	/// <param name="value">The value in Week.</param>
+	/// <returns>A new ReverberationTime instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ReverberationTime<T> FromWeeks(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.WeekToSeconds)), nameof(value)));
+/// <summary>
+	/// Creates a new ReverberationTime from a value in Nanosecond.
+	/// </summary>
+	/// <param name="value">The value in Nanosecond.</param>
+	/// <returns>A new ReverberationTime instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ReverberationTime<T> FromNanoseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Time unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReynoldsNumber.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ReynoldsNumber.g.cs
@@ -43,6 +43,48 @@ public record ReynoldsNumber<T> : PhysicalQuantity<ReynoldsNumber<T>, T>, IVecto
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static ReynoldsNumber<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>
+	/// Creates a new ReynoldsNumber from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new ReynoldsNumber instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ReynoldsNumber<T> FromGradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new ReynoldsNumber from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new ReynoldsNumber instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ReynoldsNumber<T> FromRevolutions(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new ReynoldsNumber from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new ReynoldsNumber instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ReynoldsNumber<T> FromMilliradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+/// <summary>
+	/// Creates a new ReynoldsNumber from a value in PartsPerMillion.
+	/// </summary>
+	/// <param name="value">The value in PartsPerMillion.</param>
+	/// <returns>A new ReynoldsNumber instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ReynoldsNumber<T> FromPartsPerMillion(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PartsPerMillionToRatio)), nameof(value)));
+/// <summary>
+	/// Creates a new ReynoldsNumber from a value in PartsPerBillion.
+	/// </summary>
+	/// <param name="value">The value in PartsPerBillion.</param>
+	/// <returns>A new ReynoldsNumber instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ReynoldsNumber<T> FromPartsPerBillion(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PartsPerBillionToRatio)), nameof(value)));
+/// <summary>
+	/// Creates a new ReynoldsNumber from a value in PercentByWeight.
+	/// </summary>
+	/// <param name="value">The value in PercentByWeight.</param>
+	/// <returns>A new ReynoldsNumber instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ReynoldsNumber<T> FromPercentByWeight(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PercentByWeightToRatio)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Dimensionless unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Rotation.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Rotation.g.cs
@@ -34,6 +34,24 @@ public record Rotation<T> : PhysicalQuantity<Rotation<T>, T>, IVector1<Rotation<
 	/// <returns>A new Rotation instance.</returns>
 	public static Rotation<T> FromDegrees(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
 /// <summary>
+	/// Creates a new Rotation from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new Rotation instance.</returns>
+	public static Rotation<T> FromGradians(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)));
+/// <summary>
+	/// Creates a new Rotation from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new Rotation instance.</returns>
+	public static Rotation<T> FromRevolutions(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)));
+/// <summary>
+	/// Creates a new Rotation from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new Rotation instance.</returns>
+	public static Rotation<T> FromMilliradians(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Milli)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-AngularDisplacement unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SamplingRate.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SamplingRate.g.cs
@@ -29,6 +29,20 @@ public record SamplingRate<T> : PhysicalQuantity<SamplingRate<T>, T>, IVector0<S
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static SamplingRate<T> FromHertz(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new SamplingRate from a value in Kilohertz.
+	/// </summary>
+	/// <param name="value">The value in Kilohertz.</param>
+	/// <returns>A new SamplingRate instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SamplingRate<T> FromKilohertz(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new SamplingRate from a value in Megahertz.
+	/// </summary>
+	/// <param name="value">The value in Megahertz.</param>
+	/// <returns>A new SamplingRate instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SamplingRate<T> FromMegahertz(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Mega)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Frequency unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ShearModulus.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ShearModulus.g.cs
@@ -29,6 +29,13 @@ public record ShearModulus<T> : PhysicalQuantity<ShearModulus<T>, T>, IVector0<S
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static ShearModulus<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new ShearModulus from a value in Kilopascal.
+	/// </summary>
+	/// <param name="value">The value in Kilopascal.</param>
+	/// <returns>A new ShearModulus instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ShearModulus<T> FromKilopascals(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Creates a new ShearModulus from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
@@ -49,6 +56,13 @@ public record ShearModulus<T> : PhysicalQuantity<ShearModulus<T>, T>, IVector0<S
 	/// <returns>A new ShearModulus instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static ShearModulus<T> FromPsi(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PsiToPascals)), nameof(value)));
+/// <summary>
+	/// Creates a new ShearModulus from a value in Torr.
+	/// </summary>
+	/// <param name="value">The value in Torr.</param>
+	/// <returns>A new ShearModulus instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ShearModulus<T> FromTorr(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.TorrToPascals)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Pressure unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SignedAngle.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SignedAngle.g.cs
@@ -33,6 +33,24 @@ public record SignedAngle<T> : PhysicalQuantity<SignedAngle<T>, T>, IVector1<Sig
 	/// <returns>A new <see cref="SignedAngle{T}"/> instance.</returns>
 	public static SignedAngle<T> FromDegrees(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
 /// <summary>
+	/// Creates a new <see cref="SignedAngle{T}"/> from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new <see cref="SignedAngle{T}"/> instance.</returns>
+	public static SignedAngle<T> FromGradians(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)));
+/// <summary>
+	/// Creates a new <see cref="SignedAngle{T}"/> from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new <see cref="SignedAngle{T}"/> instance.</returns>
+	public static SignedAngle<T> FromRevolutions(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)));
+/// <summary>
+	/// Creates a new <see cref="SignedAngle{T}"/> from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new <see cref="SignedAngle{T}"/> instance.</returns>
+	public static SignedAngle<T> FromMilliradians(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Milli)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-AngularDisplacement unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SignedRatio.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SignedRatio.g.cs
@@ -39,6 +39,42 @@ public record SignedRatio<T> : PhysicalQuantity<SignedRatio<T>, T>, IVector1<Sig
 	/// <returns>A new <see cref="SignedRatio{T}"/> instance.</returns>
 	public static SignedRatio<T> FromDegrees(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)));
 /// <summary>
+	/// Creates a new <see cref="SignedRatio{T}"/> from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new <see cref="SignedRatio{T}"/> instance.</returns>
+	public static SignedRatio<T> FromGradians(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)));
+/// <summary>
+	/// Creates a new <see cref="SignedRatio{T}"/> from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new <see cref="SignedRatio{T}"/> instance.</returns>
+	public static SignedRatio<T> FromRevolutions(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)));
+/// <summary>
+	/// Creates a new <see cref="SignedRatio{T}"/> from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new <see cref="SignedRatio{T}"/> instance.</returns>
+	public static SignedRatio<T> FromMilliradians(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Milli)));
+/// <summary>
+	/// Creates a new <see cref="SignedRatio{T}"/> from a value in PartsPerMillion.
+	/// </summary>
+	/// <param name="value">The value in PartsPerMillion.</param>
+	/// <returns>A new <see cref="SignedRatio{T}"/> instance.</returns>
+	public static SignedRatio<T> FromPartsPerMillion(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.PartsPerMillionToRatio)));
+/// <summary>
+	/// Creates a new <see cref="SignedRatio{T}"/> from a value in PartsPerBillion.
+	/// </summary>
+	/// <param name="value">The value in PartsPerBillion.</param>
+	/// <returns>A new <see cref="SignedRatio{T}"/> instance.</returns>
+	public static SignedRatio<T> FromPartsPerBillion(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.PartsPerBillionToRatio)));
+/// <summary>
+	/// Creates a new <see cref="SignedRatio{T}"/> from a value in PercentByWeight.
+	/// </summary>
+	/// <param name="value">The value in PercentByWeight.</param>
+	/// <returns>A new <see cref="SignedRatio{T}"/> instance.</returns>
+	public static SignedRatio<T> FromPercentByWeight(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.PercentByWeightToRatio)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Dimensionless unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SoundSpeed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SoundSpeed.g.cs
@@ -43,6 +43,20 @@ public record SoundSpeed<T> : PhysicalQuantity<SoundSpeed<T>, T>, IVector0<Sound
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static SoundSpeed<T> FromMilesPerHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MilesPerHourToMetersPerSecond)), nameof(value)));
 /// <summary>
+	/// Creates a new SoundSpeed from a value in FeetPerSecond.
+	/// </summary>
+	/// <param name="value">The value in FeetPerSecond.</param>
+	/// <returns>A new SoundSpeed instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SoundSpeed<T> FromFeetPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetPerSecondToMetersPerSecond)), nameof(value)));
+/// <summary>
+	/// Creates a new SoundSpeed from a value in Knot.
+	/// </summary>
+	/// <param name="value">The value in Knot.</param>
+	/// <returns>A new SoundSpeed instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SoundSpeed<T> FromKnots(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KnotToMetersPerSecond)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Velocity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SpecificGravity.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SpecificGravity.g.cs
@@ -43,6 +43,48 @@ public record SpecificGravity<T> : PhysicalQuantity<SpecificGravity<T>, T>, IVec
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static SpecificGravity<T> FromDegrees(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DegreeToRadians)), nameof(value)));
 /// <summary>
+	/// Creates a new SpecificGravity from a value in Gradian.
+	/// </summary>
+	/// <param name="value">The value in Gradian.</param>
+	/// <returns>A new SpecificGravity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SpecificGravity<T> FromGradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GradianToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new SpecificGravity from a value in Revolution.
+	/// </summary>
+	/// <param name="value">The value in Revolution.</param>
+	/// <returns>A new SpecificGravity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SpecificGravity<T> FromRevolutions(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.RevolutionToRadians)), nameof(value)));
+/// <summary>
+	/// Creates a new SpecificGravity from a value in Milliradian.
+	/// </summary>
+	/// <param name="value">The value in Milliradian.</param>
+	/// <returns>A new SpecificGravity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SpecificGravity<T> FromMilliradians(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
+/// <summary>
+	/// Creates a new SpecificGravity from a value in PartsPerMillion.
+	/// </summary>
+	/// <param name="value">The value in PartsPerMillion.</param>
+	/// <returns>A new SpecificGravity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SpecificGravity<T> FromPartsPerMillion(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PartsPerMillionToRatio)), nameof(value)));
+/// <summary>
+	/// Creates a new SpecificGravity from a value in PartsPerBillion.
+	/// </summary>
+	/// <param name="value">The value in PartsPerBillion.</param>
+	/// <returns>A new SpecificGravity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SpecificGravity<T> FromPartsPerBillion(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PartsPerBillionToRatio)), nameof(value)));
+/// <summary>
+	/// Creates a new SpecificGravity from a value in PercentByWeight.
+	/// </summary>
+	/// <param name="value">The value in PercentByWeight.</param>
+	/// <returns>A new SpecificGravity instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SpecificGravity<T> FromPercentByWeight(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PercentByWeightToRatio)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Dimensionless unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Speed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Speed.g.cs
@@ -42,6 +42,20 @@ public record Speed<T> : PhysicalQuantity<Speed<T>, T>, IVector0<Speed<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Speed<T> FromMilesPerHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MilesPerHourToMetersPerSecond)), nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Speed{T}"/> from a value in FeetPerSecond.
+	/// </summary>
+	/// <param name="value">The value in FeetPerSecond.</param>
+	/// <returns>A new <see cref="Speed{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Speed<T> FromFeetPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetPerSecondToMetersPerSecond)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Speed{T}"/> from a value in Knot.
+	/// </summary>
+	/// <param name="value">The value in Knot.</param>
+	/// <returns>A new <see cref="Speed{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Speed<T> FromKnots(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KnotToMetersPerSecond)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Velocity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Stress.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Stress.g.cs
@@ -29,6 +29,13 @@ public record Stress<T> : PhysicalQuantity<Stress<T>, T>, IVector0<Stress<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Stress<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new Stress from a value in Kilopascal.
+	/// </summary>
+	/// <param name="value">The value in Kilopascal.</param>
+	/// <returns>A new Stress instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Stress<T> FromKilopascals(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Creates a new Stress from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
@@ -49,6 +56,13 @@ public record Stress<T> : PhysicalQuantity<Stress<T>, T>, IVector0<Stress<T>, T>
 	/// <returns>A new Stress instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Stress<T> FromPsi(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PsiToPascals)), nameof(value)));
+/// <summary>
+	/// Creates a new Stress from a value in Torr.
+	/// </summary>
+	/// <param name="value">The value in Torr.</param>
+	/// <returns>A new Stress instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Stress<T> FromTorr(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.TorrToPascals)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Pressure unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SurfaceArea.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SurfaceArea.g.cs
@@ -29,6 +29,20 @@ public record SurfaceArea<T> : PhysicalQuantity<SurfaceArea<T>, T>, IVector0<Sur
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static SurfaceArea<T> FromSquareMeters(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new SurfaceArea from a value in SquareKilometer.
+	/// </summary>
+	/// <param name="value">The value in SquareKilometer.</param>
+	/// <returns>A new SurfaceArea instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SurfaceArea<T> FromSquareKilometers(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareKilometerToSquareMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new SurfaceArea from a value in SquareCentimeter.
+	/// </summary>
+	/// <param name="value">The value in SquareCentimeter.</param>
+	/// <returns>A new SurfaceArea instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SurfaceArea<T> FromSquareCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareCentimeterToSquareMeters)), nameof(value)));
+/// <summary>
 	/// Creates a new SurfaceArea from a value in SquareFoot.
 	/// </summary>
 	/// <param name="value">The value in SquareFoot.</param>
@@ -42,6 +56,27 @@ public record SurfaceArea<T> : PhysicalQuantity<SurfaceArea<T>, T>, IVector0<Sur
 	/// <returns>A new SurfaceArea instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static SurfaceArea<T> FromSquareInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareInchToSquareMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new SurfaceArea from a value in SquareMile.
+	/// </summary>
+	/// <param name="value">The value in SquareMile.</param>
+	/// <returns>A new SurfaceArea instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SurfaceArea<T> FromSquareMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.SquareMileToSquareMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new SurfaceArea from a value in Hectare.
+	/// </summary>
+	/// <param name="value">The value in Hectare.</param>
+	/// <returns>A new SurfaceArea instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SurfaceArea<T> FromHectares(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.HectareToSquareMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new SurfaceArea from a value in Acre.
+	/// </summary>
+	/// <param name="value">The value in Acre.</param>
+	/// <returns>A new SurfaceArea instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SurfaceArea<T> FromAcres(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.AcreToSquareMeters)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Area unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SurfaceTension.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/SurfaceTension.g.cs
@@ -28,6 +28,13 @@ public record SurfaceTension<T> : PhysicalQuantity<SurfaceTension<T>, T>, IVecto
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static SurfaceTension<T> FromNewtonPerMeter(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="SurfaceTension{T}"/> from a value in DynePerCentimeter.
+	/// </summary>
+	/// <param name="value">The value in DynePerCentimeter.</param>
+	/// <returns>A new <see cref="SurfaceTension{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static SurfaceTension<T> FromDynePerCentimeter(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DynePerCentimeterToNewtonPerMeter)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-SurfaceTension unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Temperature.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Temperature.g.cs
@@ -42,6 +42,13 @@ public record Temperature<T> : PhysicalQuantity<Temperature<T>, T>, IVector0<Tem
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Temperature<T> FromFahrenheit(T value) => Create(Vector0Guards.EnsureNonNegative(((value * T.CreateChecked(Units.ConversionConstants.FahrenheitScale)) + T.CreateChecked(Units.ConversionConstants.FahrenheitToKelvinOffset)), nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Temperature{T}"/> from a value in Rankine.
+	/// </summary>
+	/// <param name="value">The value in Rankine.</param>
+	/// <returns>A new <see cref="Temperature{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Temperature<T> FromRankine(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FahrenheitScale)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Temperature unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TemperatureDelta.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TemperatureDelta.g.cs
@@ -39,6 +39,12 @@ public record TemperatureDelta<T> : PhysicalQuantity<TemperatureDelta<T>, T>, IV
 	/// <returns>A new <see cref="TemperatureDelta{T}"/> instance.</returns>
 	public static TemperatureDelta<T> FromFahrenheit(T value) => Create(((value * T.CreateChecked(Units.ConversionConstants.FahrenheitScale)) + T.CreateChecked(Units.ConversionConstants.FahrenheitToKelvinOffset)));
 /// <summary>
+	/// Creates a new <see cref="TemperatureDelta{T}"/> from a value in Rankine.
+	/// </summary>
+	/// <param name="value">The value in Rankine.</param>
+	/// <returns>A new <see cref="TemperatureDelta{T}"/> instance.</returns>
+	public static TemperatureDelta<T> FromRankine(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.FahrenheitScale)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Temperature unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TemperatureDrop.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TemperatureDrop.g.cs
@@ -40,6 +40,12 @@ public record TemperatureDrop<T> : PhysicalQuantity<TemperatureDrop<T>, T>, IVec
 	/// <returns>A new TemperatureDrop instance.</returns>
 	public static TemperatureDrop<T> FromFahrenheit(T value) => Create(((value * T.CreateChecked(Units.ConversionConstants.FahrenheitScale)) + T.CreateChecked(Units.ConversionConstants.FahrenheitToKelvinOffset)));
 /// <summary>
+	/// Creates a new TemperatureDrop from a value in Rankine.
+	/// </summary>
+	/// <param name="value">The value in Rankine.</param>
+	/// <returns>A new TemperatureDrop instance.</returns>
+	public static TemperatureDrop<T> FromRankine(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.FahrenheitScale)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Temperature unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TemperatureRise.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TemperatureRise.g.cs
@@ -40,6 +40,12 @@ public record TemperatureRise<T> : PhysicalQuantity<TemperatureRise<T>, T>, IVec
 	/// <returns>A new TemperatureRise instance.</returns>
 	public static TemperatureRise<T> FromFahrenheit(T value) => Create(((value * T.CreateChecked(Units.ConversionConstants.FahrenheitScale)) + T.CreateChecked(Units.ConversionConstants.FahrenheitToKelvinOffset)));
 /// <summary>
+	/// Creates a new TemperatureRise from a value in Rankine.
+	/// </summary>
+	/// <param name="value">The value in Rankine.</param>
+	/// <returns>A new TemperatureRise instance.</returns>
+	public static TemperatureRise<T> FromRankine(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.FahrenheitScale)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Temperature unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Tension.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Tension.g.cs
@@ -29,6 +29,27 @@ public record Tension<T> : PhysicalQuantity<Tension<T>, T>, IVector0<Tension<T>,
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Tension<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new Tension from a value in Kilonewton.
+	/// </summary>
+	/// <param name="value">The value in Kilonewton.</param>
+	/// <returns>A new Tension instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Tension<T> FromKilonewtons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new Tension from a value in Dyne.
+	/// </summary>
+	/// <param name="value">The value in Dyne.</param>
+	/// <returns>A new Tension instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Tension<T> FromDynes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DyneToNewtons)), nameof(value)));
+/// <summary>
+	/// Creates a new Tension from a value in PoundForce.
+	/// </summary>
+	/// <param name="value">The value in PoundForce.</param>
+	/// <returns>A new Tension instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Tension<T> FromPoundsForce(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundForceToNewtons)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Force unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ThermalEnergy.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/ThermalEnergy.g.cs
@@ -29,6 +29,13 @@ public record ThermalEnergy<T> : PhysicalQuantity<ThermalEnergy<T>, T>, IVector0
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static ThermalEnergy<T> FromJoules(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new ThermalEnergy from a value in Kilojoule.
+	/// </summary>
+	/// <param name="value">The value in Kilojoule.</param>
+	/// <returns>A new ThermalEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ThermalEnergy<T> FromKilojoules(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Creates a new ThermalEnergy from a value in ElectronVolt.
 	/// </summary>
 	/// <param name="value">The value in ElectronVolt.</param>
@@ -43,12 +50,40 @@ public record ThermalEnergy<T> : PhysicalQuantity<ThermalEnergy<T>, T>, IVector0
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static ThermalEnergy<T> FromCalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
 /// <summary>
+	/// Creates a new ThermalEnergy from a value in Kilocalorie.
+	/// </summary>
+	/// <param name="value">The value in Kilocalorie.</param>
+	/// <returns>A new ThermalEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ThermalEnergy<T> FromKilocalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilocalorieToJoules)), nameof(value)));
+/// <summary>
 	/// Creates a new ThermalEnergy from a value in KilowattHour.
 	/// </summary>
 	/// <param name="value">The value in KilowattHour.</param>
 	/// <returns>A new ThermalEnergy instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static ThermalEnergy<T> FromKilowattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new ThermalEnergy from a value in WattHour.
+	/// </summary>
+	/// <param name="value">The value in WattHour.</param>
+	/// <returns>A new ThermalEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ThermalEnergy<T> FromWattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.WattHourToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new ThermalEnergy from a value in Erg.
+	/// </summary>
+	/// <param name="value">The value in Erg.</param>
+	/// <returns>A new ThermalEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ThermalEnergy<T> FromErgs(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ErgToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new ThermalEnergy from a value in Btu.
+	/// </summary>
+	/// <param name="value">The value in Btu.</param>
+	/// <returns>A new ThermalEnergy instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static ThermalEnergy<T> FromBtus(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BtuToJoules)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Energy unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Thickness.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Thickness.g.cs
@@ -99,6 +99,13 @@ public record Thickness<T> : PhysicalQuantity<Thickness<T>, T>, IVector0<Thickne
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Thickness<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>
+	/// Creates a new Thickness from a value in NauticalMile.
+	/// </summary>
+	/// <param name="value">The value in NauticalMile.</param>
+	/// <returns>A new Thickness instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Thickness<T> FromNauticalMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.NauticalMileToMeters)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Length unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Thrust.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Thrust.g.cs
@@ -29,6 +29,27 @@ public record Thrust<T> : PhysicalQuantity<Thrust<T>, T>, IVector0<Thrust<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Thrust<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new Thrust from a value in Kilonewton.
+	/// </summary>
+	/// <param name="value">The value in Kilonewton.</param>
+	/// <returns>A new Thrust instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Thrust<T> FromKilonewtons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new Thrust from a value in Dyne.
+	/// </summary>
+	/// <param name="value">The value in Dyne.</param>
+	/// <returns>A new Thrust instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Thrust<T> FromDynes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DyneToNewtons)), nameof(value)));
+/// <summary>
+	/// Creates a new Thrust from a value in PoundForce.
+	/// </summary>
+	/// <param name="value">The value in PoundForce.</param>
+	/// <returns>A new Thrust instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Thrust<T> FromPoundsForce(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundForceToNewtons)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Force unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TimeConstant.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/TimeConstant.g.cs
@@ -71,6 +71,20 @@ public record TimeConstant<T> : PhysicalQuantity<TimeConstant<T>, T>, IVector0<T
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static TimeConstant<T> FromYears(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.YearToSeconds)), nameof(value)));
 /// <summary>
+	/// Creates a new TimeConstant from a value in Week.
+	/// </summary>
+	/// <param name="value">The value in Week.</param>
+	/// <returns>A new TimeConstant instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static TimeConstant<T> FromWeeks(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.WeekToSeconds)), nameof(value)));
+/// <summary>
+	/// Creates a new TimeConstant from a value in Nanosecond.
+	/// </summary>
+	/// <param name="value">The value in Nanosecond.</param>
+	/// <returns>A new TimeConstant instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static TimeConstant<T> FromNanoseconds(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Nano)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Time unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Velocity1D.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Velocity1D.g.cs
@@ -39,6 +39,18 @@ public record Velocity1D<T> : PhysicalQuantity<Velocity1D<T>, T>, IVector1<Veloc
 	/// <returns>A new <see cref="Velocity1D{T}"/> instance.</returns>
 	public static Velocity1D<T> FromMilesPerHour(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.MilesPerHourToMetersPerSecond)));
 /// <summary>
+	/// Creates a new <see cref="Velocity1D{T}"/> from a value in FeetPerSecond.
+	/// </summary>
+	/// <param name="value">The value in FeetPerSecond.</param>
+	/// <returns>A new <see cref="Velocity1D{T}"/> instance.</returns>
+	public static Velocity1D<T> FromFeetPerSecond(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.FeetPerSecondToMetersPerSecond)));
+/// <summary>
+	/// Creates a new <see cref="Velocity1D{T}"/> from a value in Knot.
+	/// </summary>
+	/// <param name="value">The value in Knot.</param>
+	/// <returns>A new <see cref="Velocity1D{T}"/> instance.</returns>
+	public static Velocity1D<T> FromKnots(T value) => Create((value * T.CreateChecked(Units.ConversionConstants.KnotToMetersPerSecond)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Velocity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Voltage.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Voltage.g.cs
@@ -27,6 +27,12 @@ public record Voltage<T> : PhysicalQuantity<Voltage<T>, T>, IVector1<Voltage<T>,
 	/// <returns>A new <see cref="Voltage{T}"/> instance.</returns>
 	public static Voltage<T> FromVolts(T value) => Create(value);
 /// <summary>
+	/// Creates a new <see cref="Voltage{T}"/> from a value in Kilovolt.
+	/// </summary>
+	/// <param name="value">The value in Kilovolt.</param>
+	/// <returns>A new <see cref="Voltage{T}"/> instance.</returns>
+	public static Voltage<T> FromKilovolts(T value) => Create((value * T.CreateChecked(MetricMagnitudes.Kilo)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-ElectricPotential unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VoltageDrop.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VoltageDrop.g.cs
@@ -29,6 +29,13 @@ public record VoltageDrop<T> : PhysicalQuantity<VoltageDrop<T>, T>, IVector0<Vol
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static VoltageDrop<T> FromVolts(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new VoltageDrop from a value in Kilovolt.
+	/// </summary>
+	/// <param name="value">The value in Kilovolt.</param>
+	/// <returns>A new VoltageDrop instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static VoltageDrop<T> FromKilovolts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-ElectricPotential unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VoltageMagnitude.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/VoltageMagnitude.g.cs
@@ -28,6 +28,13 @@ public record VoltageMagnitude<T> : PhysicalQuantity<VoltageMagnitude<T>, T>, IV
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static VoltageMagnitude<T> FromVolts(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="VoltageMagnitude{T}"/> from a value in Kilovolt.
+	/// </summary>
+	/// <param name="value">The value in Kilovolt.</param>
+	/// <returns>A new <see cref="VoltageMagnitude{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static VoltageMagnitude<T> FromKilovolts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-ElectricPotential unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Volume.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Volume.g.cs
@@ -42,12 +42,61 @@ public record Volume<T> : PhysicalQuantity<Volume<T>, T>, IVector0<Volume<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Volume<T> FromMilliliters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Milli)), nameof(value)));
 /// <summary>
+	/// Creates a new <see cref="Volume{T}"/> from a value in CubicCentimeter.
+	/// </summary>
+	/// <param name="value">The value in CubicCentimeter.</param>
+	/// <returns>A new <see cref="Volume{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Volume<T> FromCubicCentimeters(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CubicCentimeterToCubicMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Volume{T}"/> from a value in CubicFoot.
+	/// </summary>
+	/// <param name="value">The value in CubicFoot.</param>
+	/// <returns>A new <see cref="Volume{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Volume<T> FromCubicFeet(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CubicFootToCubicMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Volume{T}"/> from a value in CubicInch.
+	/// </summary>
+	/// <param name="value">The value in CubicInch.</param>
+	/// <returns>A new <see cref="Volume{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Volume<T> FromCubicInches(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CubicInchToCubicMeters)), nameof(value)));
+/// <summary>
 	/// Creates a new <see cref="Volume{T}"/> from a value in Gallon.
 	/// </summary>
 	/// <param name="value">The value in Gallon.</param>
 	/// <returns>A new <see cref="Volume{T}"/> instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Volume<T> FromGallons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.GallonToCubicMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Volume{T}"/> from a value in ImperialGallon.
+	/// </summary>
+	/// <param name="value">The value in ImperialGallon.</param>
+	/// <returns>A new <see cref="Volume{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Volume<T> FromImperialGallons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ImperialGallonToCubicMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Volume{T}"/> from a value in USQuart.
+	/// </summary>
+	/// <param name="value">The value in USQuart.</param>
+	/// <returns>A new <see cref="Volume{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Volume<T> FromUSQuarts(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.USQuartToCubicMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Volume{T}"/> from a value in USPint.
+	/// </summary>
+	/// <param name="value">The value in USPint.</param>
+	/// <returns>A new <see cref="Volume{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Volume<T> FromUSPints(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.USPintToCubicMeters)), nameof(value)));
+/// <summary>
+	/// Creates a new <see cref="Volume{T}"/> from a value in USFluidOunce.
+	/// </summary>
+	/// <param name="value">The value in USFluidOunce.</param>
+	/// <returns>A new <see cref="Volume{T}"/> instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Volume<T> FromUSFluidOunces(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.USFluidOunceToCubicMeters)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Volume unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Wavelength.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Wavelength.g.cs
@@ -99,6 +99,13 @@ public record Wavelength<T> : PhysicalQuantity<Wavelength<T>, T>, IVector0<Wavel
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Wavelength<T> FromMiles(T value) => Create(Vector0Guards.EnsurePositive((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>
+	/// Creates a new Wavelength from a value in NauticalMile.
+	/// </summary>
+	/// <param name="value">The value in NauticalMile.</param>
+	/// <returns>A new Wavelength instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Wavelength<T> FromNauticalMiles(T value) => Create(Vector0Guards.EnsurePositive((value * T.CreateChecked(Units.ConversionConstants.NauticalMileToMeters)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Length unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Weight.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Weight.g.cs
@@ -29,6 +29,27 @@ public record Weight<T> : PhysicalQuantity<Weight<T>, T>, IVector0<Weight<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Weight<T> FromNewtons(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new Weight from a value in Kilonewton.
+	/// </summary>
+	/// <param name="value">The value in Kilonewton.</param>
+	/// <returns>A new Weight instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Weight<T> FromKilonewtons(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
+	/// Creates a new Weight from a value in Dyne.
+	/// </summary>
+	/// <param name="value">The value in Dyne.</param>
+	/// <returns>A new Weight instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Weight<T> FromDynes(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.DyneToNewtons)), nameof(value)));
+/// <summary>
+	/// Creates a new Weight from a value in PoundForce.
+	/// </summary>
+	/// <param name="value">The value in PoundForce.</param>
+	/// <returns>A new Weight instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Weight<T> FromPoundsForce(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PoundForceToNewtons)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Force unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Width.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Width.g.cs
@@ -99,6 +99,13 @@ public record Width<T> : PhysicalQuantity<Width<T>, T>, IVector0<Width<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Width<T> FromMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MileToMeters)), nameof(value)));
 /// <summary>
+	/// Creates a new Width from a value in NauticalMile.
+	/// </summary>
+	/// <param name="value">The value in NauticalMile.</param>
+	/// <returns>A new Width instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Width<T> FromNauticalMiles(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.NauticalMileToMeters)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Length unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/WindSpeed.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/WindSpeed.g.cs
@@ -43,6 +43,20 @@ public record WindSpeed<T> : PhysicalQuantity<WindSpeed<T>, T>, IVector0<WindSpe
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static WindSpeed<T> FromMilesPerHour(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.MilesPerHourToMetersPerSecond)), nameof(value)));
 /// <summary>
+	/// Creates a new WindSpeed from a value in FeetPerSecond.
+	/// </summary>
+	/// <param name="value">The value in FeetPerSecond.</param>
+	/// <returns>A new WindSpeed instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static WindSpeed<T> FromFeetPerSecond(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.FeetPerSecondToMetersPerSecond)), nameof(value)));
+/// <summary>
+	/// Creates a new WindSpeed from a value in Knot.
+	/// </summary>
+	/// <param name="value">The value in Knot.</param>
+	/// <returns>A new WindSpeed instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static WindSpeed<T> FromKnots(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KnotToMetersPerSecond)), nameof(value)));
+/// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Velocity unit) fail at compile time.
 	/// </summary>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Work.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/Work.g.cs
@@ -29,6 +29,13 @@ public record Work<T> : PhysicalQuantity<Work<T>, T>, IVector0<Work<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Work<T> FromJoules(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new Work from a value in Kilojoule.
+	/// </summary>
+	/// <param name="value">The value in Kilojoule.</param>
+	/// <returns>A new Work instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Work<T> FromKilojoules(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Creates a new Work from a value in ElectronVolt.
 	/// </summary>
 	/// <param name="value">The value in ElectronVolt.</param>
@@ -43,12 +50,40 @@ public record Work<T> : PhysicalQuantity<Work<T>, T>, IVector0<Work<T>, T>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Work<T> FromCalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.CalorieToJoules)), nameof(value)));
 /// <summary>
+	/// Creates a new Work from a value in Kilocalorie.
+	/// </summary>
+	/// <param name="value">The value in Kilocalorie.</param>
+	/// <returns>A new Work instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Work<T> FromKilocalories(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilocalorieToJoules)), nameof(value)));
+/// <summary>
 	/// Creates a new Work from a value in KilowattHour.
 	/// </summary>
 	/// <param name="value">The value in KilowattHour.</param>
 	/// <returns>A new Work instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static Work<T> FromKilowattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.KilowattHourToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new Work from a value in WattHour.
+	/// </summary>
+	/// <param name="value">The value in WattHour.</param>
+	/// <returns>A new Work instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Work<T> FromWattHours(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.WattHourToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new Work from a value in Erg.
+	/// </summary>
+	/// <param name="value">The value in Erg.</param>
+	/// <returns>A new Work instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Work<T> FromErgs(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.ErgToJoules)), nameof(value)));
+/// <summary>
+	/// Creates a new Work from a value in Btu.
+	/// </summary>
+	/// <param name="value">The value in Btu.</param>
+	/// <returns>A new Work instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static Work<T> FromBtus(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.BtuToJoules)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Energy unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/YoungsModulus.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.QuantitiesGenerator/YoungsModulus.g.cs
@@ -29,6 +29,13 @@ public record YoungsModulus<T> : PhysicalQuantity<YoungsModulus<T>, T>, IVector0
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static YoungsModulus<T> FromPascals(T value) => Create(Vector0Guards.EnsureNonNegative(value, nameof(value)));
 /// <summary>
+	/// Creates a new YoungsModulus from a value in Kilopascal.
+	/// </summary>
+	/// <param name="value">The value in Kilopascal.</param>
+	/// <returns>A new YoungsModulus instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static YoungsModulus<T> FromKilopascals(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(MetricMagnitudes.Kilo)), nameof(value)));
+/// <summary>
 	/// Creates a new YoungsModulus from a value in Bar.
 	/// </summary>
 	/// <param name="value">The value in Bar.</param>
@@ -49,6 +56,13 @@ public record YoungsModulus<T> : PhysicalQuantity<YoungsModulus<T>, T>, IVector0
 	/// <returns>A new YoungsModulus instance.</returns>
 	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
 	public static YoungsModulus<T> FromPsi(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.PsiToPascals)), nameof(value)));
+/// <summary>
+	/// Creates a new YoungsModulus from a value in Torr.
+	/// </summary>
+	/// <param name="value">The value in Torr.</param>
+	/// <returns>A new YoungsModulus instance.</returns>
+	/// <exception cref="System.ArgumentException">Thrown when the resulting magnitude would be negative.</exception>
+	public static YoungsModulus<T> FromTorr(T value) => Create(Vector0Guards.EnsureNonNegative((value * T.CreateChecked(Units.ConversionConstants.TorrToPascals)), nameof(value)));
 /// <summary>
 	/// Converts this quantity's SI-base value to the value in <paramref name="unit"/>.
 	/// Cross-dimension calls (e.g. passing a non-Pressure unit) fail at compile time.

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.UnitsGenerator/Units.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.UnitsGenerator/Units.g.cs
@@ -933,6 +933,678 @@ public sealed record Degree : IUnit, IDimensionlessUnit, IAngularDisplacementUni
 };
 
 /// <summary>
+/// Nautical mile - 1852 meters, used in navigation.
+/// </summary>
+public sealed record NauticalMile : IUnit, ILengthUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "NauticalMile";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "nmi";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Length;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => NauticalMileToMeters;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public NauticalMile() { }
+
+};
+
+/// <summary>
+/// Stone - Imperial unit of mass (14 pounds).
+/// </summary>
+public sealed record Stone : IUnit, IMassUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Stone";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "st";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Imperial;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Mass;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => StoneToKilograms;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Stone() { }
+
+};
+
+/// <summary>
+/// Short ton - US customary unit of mass (2000 pounds).
+/// </summary>
+public sealed record ShortTon : IUnit, IMassUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "ShortTon";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "ton";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.USCustomary;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Mass;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => ShortTonToKilograms;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public ShortTon() { }
+
+};
+
+/// <summary>
+/// Atomic mass unit - 1/12 the mass of a carbon-12 atom.
+/// </summary>
+public sealed record AtomicMassUnit : IUnit, IMassUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "AtomicMassUnit";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "u";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Atomic;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Mass;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => AtomicMassUnitToKilograms;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public AtomicMassUnit() { }
+
+};
+
+/// <summary>
+/// Week - 7 days.
+/// </summary>
+public sealed record Week : IUnit, ITimeUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Week";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "wk";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Time;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => WeekToSeconds;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Week() { }
+
+};
+
+/// <summary>
+/// Nanosecond - 1e-9 seconds.
+/// </summary>
+public sealed record Nanosecond : IUnit, ITimeUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Nanosecond";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "ns";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Time;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Nano;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Nanosecond() { }
+
+};
+
+/// <summary>
+/// Square kilometer - 1e6 square meters.
+/// </summary>
+public sealed record SquareKilometer : IUnit, IAreaUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "SquareKilometer";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "km²";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Area;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => SquareKilometerToSquareMeters;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public SquareKilometer() { }
+
+};
+
+/// <summary>
+/// Square centimeter - 1e-4 square meters.
+/// </summary>
+public sealed record SquareCentimeter : IUnit, IAreaUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "SquareCentimeter";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "cm²";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Area;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => SquareCentimeterToSquareMeters;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public SquareCentimeter() { }
+
+};
+
+/// <summary>
+/// Square mile - Imperial unit of area.
+/// </summary>
+public sealed record SquareMile : IUnit, IAreaUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "SquareMile";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "mi²";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Imperial;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Area;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => SquareMileToSquareMeters;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public SquareMile() { }
+
+};
+
+/// <summary>
+/// Hectare - metric unit of area (10000 m²).
+/// </summary>
+public sealed record Hectare : IUnit, IAreaUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Hectare";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "ha";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Metric;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Area;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => HectareToSquareMeters;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Hectare() { }
+
+};
+
+/// <summary>
+/// Acre - Imperial unit of area.
+/// </summary>
+public sealed record Acre : IUnit, IAreaUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Acre";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "ac";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Imperial;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Area;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => AcreToSquareMeters;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Acre() { }
+
+};
+
+/// <summary>
+/// Cubic centimeter - 1e-6 cubic meters.
+/// </summary>
+public sealed record CubicCentimeter : IUnit, IVolumeUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "CubicCentimeter";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "cm³";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Volume;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => CubicCentimeterToCubicMeters;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public CubicCentimeter() { }
+
+};
+
+/// <summary>
+/// Cubic foot - Imperial unit of volume.
+/// </summary>
+public sealed record CubicFoot : IUnit, IVolumeUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "CubicFoot";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "ft³";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Imperial;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Volume;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => CubicFootToCubicMeters;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public CubicFoot() { }
+
+};
+
+/// <summary>
+/// Cubic inch - Imperial unit of volume.
+/// </summary>
+public sealed record CubicInch : IUnit, IVolumeUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "CubicInch";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "in³";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Imperial;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Volume;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => CubicInchToCubicMeters;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public CubicInch() { }
+
+};
+
+/// <summary>
+/// Imperial gallon - British unit of volume.
+/// </summary>
+public sealed record ImperialGallon : IUnit, IVolumeUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "ImperialGallon";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "imp gal";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Imperial;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Volume;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => ImperialGallonToCubicMeters;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public ImperialGallon() { }
+
+};
+
+/// <summary>
+/// US liquid quart - US customary unit of volume.
+/// </summary>
+public sealed record USQuart : IUnit, IVolumeUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "USQuart";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "qt";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.USCustomary;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Volume;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => USQuartToCubicMeters;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public USQuart() { }
+
+};
+
+/// <summary>
+/// US liquid pint - US customary unit of volume.
+/// </summary>
+public sealed record USPint : IUnit, IVolumeUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "USPint";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "pt";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.USCustomary;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Volume;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => USPintToCubicMeters;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public USPint() { }
+
+};
+
+/// <summary>
+/// US fluid ounce - US customary unit of volume.
+/// </summary>
+public sealed record USFluidOunce : IUnit, IVolumeUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "USFluidOunce";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "fl oz";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.USCustomary;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Volume;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => USFluidOunceToCubicMeters;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public USFluidOunce() { }
+
+};
+
+/// <summary>
+/// Gradian - 1/400 of a full circle (π/200 rad).
+/// </summary>
+public sealed record Gradian : IUnit, IDimensionlessUnit, IAngularDisplacementUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Gradian";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "grad";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Dimensionless;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => GradianToRadians;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Gradian() { }
+
+};
+
+/// <summary>
+/// Revolution - one full circle (2π rad).
+/// </summary>
+public sealed record Revolution : IUnit, IDimensionlessUnit, IAngularDisplacementUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Revolution";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "rev";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Dimensionless;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => RevolutionToRadians;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Revolution() { }
+
+};
+
+/// <summary>
+/// Milliradian - 0.001 radians.
+/// </summary>
+public sealed record Milliradian : IUnit, IDimensionlessUnit, IAngularDisplacementUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Milliradian";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "mrad";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Dimensionless;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Milli;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Milliradian() { }
+
+};
+
+/// <summary>
+/// Parts per million - 1e-6 dimensionless ratio.
+/// </summary>
+public sealed record PartsPerMillion : IUnit, IDimensionlessUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "PartsPerMillion";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "ppm";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Dimensionless;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => PartsPerMillionToRatio;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public PartsPerMillion() { }
+
+};
+
+/// <summary>
+/// Parts per billion - 1e-9 dimensionless ratio.
+/// </summary>
+public sealed record PartsPerBillion : IUnit, IDimensionlessUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "PartsPerBillion";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "ppb";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Dimensionless;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => PartsPerBillionToRatio;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public PartsPerBillion() { }
+
+};
+
+/// <summary>
+/// Percent by weight - mass fraction expressed as a percentage.
+/// </summary>
+public sealed record PercentByWeight : IUnit, IDimensionlessUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "PercentByWeight";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "% w/w";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Dimensionless;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => PercentByWeightToRatio;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public PercentByWeight() { }
+
+};
+
+/// <summary>
 /// Newton - SI derived unit of force.
 /// </summary>
 public sealed record Newton : IUnit, IForceUnit
@@ -1549,6 +2221,426 @@ public sealed record MetersPerSecondQuartic : IUnit, ISnapUnit
 };
 
 /// <summary>
+/// Feet per second - Imperial unit of velocity.
+/// </summary>
+public sealed record FeetPerSecond : IUnit, IVelocityUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "FeetPerSecond";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "ft/s";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Imperial;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Velocity;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => FeetPerSecondToMetersPerSecond;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public FeetPerSecond() { }
+
+};
+
+/// <summary>
+/// Knot - one nautical mile per hour.
+/// </summary>
+public sealed record Knot : IUnit, IVelocityUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Knot";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "kn";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Velocity;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => KnotToMetersPerSecond;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Knot() { }
+
+};
+
+/// <summary>
+/// Standard gravity - acceleration of free fall at Earth's surface.
+/// </summary>
+public sealed record StandardGravity : IUnit, IAccelerationUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "StandardGravity";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "g";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Acceleration;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => StandardGravityToMetersPerSecondSquared;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public StandardGravity() { }
+
+};
+
+/// <summary>
+/// Kilonewton - 1000 newtons.
+/// </summary>
+public sealed record Kilonewton : IUnit, IForceUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Kilonewton";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "kN";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Force;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Kilo;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Kilonewton() { }
+
+};
+
+/// <summary>
+/// Dyne - CGS unit of force.
+/// </summary>
+public sealed record Dyne : IUnit, IForceUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Dyne";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "dyn";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.CGS;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Force;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => DyneToNewtons;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Dyne() { }
+
+};
+
+/// <summary>
+/// Pound-force - Imperial unit of force.
+/// </summary>
+public sealed record PoundForce : IUnit, IForceUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "PoundForce";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "lbf";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Imperial;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Force;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => PoundForceToNewtons;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public PoundForce() { }
+
+};
+
+/// <summary>
+/// Kilopascal - 1000 pascals.
+/// </summary>
+public sealed record Kilopascal : IUnit, IPressureUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Kilopascal";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "kPa";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Pressure;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Kilo;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Kilopascal() { }
+
+};
+
+/// <summary>
+/// Torr - 1/760 of a standard atmosphere.
+/// </summary>
+public sealed record Torr : IUnit, IPressureUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Torr";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "Torr";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Pressure;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => TorrToPascals;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Torr() { }
+
+};
+
+/// <summary>
+/// Kilojoule - 1000 joules.
+/// </summary>
+public sealed record Kilojoule : IUnit, IEnergyUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Kilojoule";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "kJ";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Energy;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Kilo;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Kilojoule() { }
+
+};
+
+/// <summary>
+/// Kilocalorie - 1000 thermochemical calories.
+/// </summary>
+public sealed record Kilocalorie : IUnit, IEnergyUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Kilocalorie";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "kcal";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Energy;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => KilocalorieToJoules;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Kilocalorie() { }
+
+};
+
+/// <summary>
+/// Watt-hour - 3600 joules.
+/// </summary>
+public sealed record WattHour : IUnit, IEnergyUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "WattHour";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "Wh";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Energy;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => WattHourToJoules;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public WattHour() { }
+
+};
+
+/// <summary>
+/// Erg - CGS unit of energy.
+/// </summary>
+public sealed record Erg : IUnit, IEnergyUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Erg";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "erg";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.CGS;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Energy;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => ErgToJoules;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Erg() { }
+
+};
+
+/// <summary>
+/// British thermal unit (IT) - Imperial unit of energy.
+/// </summary>
+public sealed record Btu : IUnit, IEnergyUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Btu";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "BTU";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Imperial;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Energy;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => BtuToJoules;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Btu() { }
+
+};
+
+/// <summary>
+/// Kilowatt - 1000 watts.
+/// </summary>
+public sealed record Kilowatt : IUnit, IPowerUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Kilowatt";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "kW";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Power;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Kilo;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Kilowatt() { }
+
+};
+
+/// <summary>
+/// Megawatt - 1e6 watts.
+/// </summary>
+public sealed record Megawatt : IUnit, IPowerUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Megawatt";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "MW";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Power;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Mega;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Megawatt() { }
+
+};
+
+/// <summary>
 /// Kelvin - SI base unit of thermodynamic temperature.
 /// </summary>
 public sealed record Kelvin : IUnit, ITemperatureUnit
@@ -1769,6 +2861,34 @@ public sealed record PerKelvin : IUnit, IThermalExpansionUnit
 
 	/// <summary>Initializes a new instance of the unit.</summary>
 	public PerKelvin() { }
+
+};
+
+/// <summary>
+/// Rankine - absolute temperature scale with Fahrenheit-sized degrees.
+/// </summary>
+public sealed record Rankine : IUnit, ITemperatureUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Rankine";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "°R";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Imperial;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Temperature;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => FahrenheitScale;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Rankine() { }
 
 };
 
@@ -2081,6 +3201,258 @@ public sealed record Henry : IUnit, IInductanceUnit
 };
 
 /// <summary>
+/// Milliampere - 0.001 amperes.
+/// </summary>
+public sealed record Milliampere : IUnit, IElectricCurrentUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Milliampere";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "mA";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.ElectricCurrent;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Milli;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Milliampere() { }
+
+};
+
+/// <summary>
+/// Kiloampere - 1000 amperes.
+/// </summary>
+public sealed record Kiloampere : IUnit, IElectricCurrentUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Kiloampere";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "kA";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.ElectricCurrent;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Kilo;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Kiloampere() { }
+
+};
+
+/// <summary>
+/// Kilovolt - 1000 volts.
+/// </summary>
+public sealed record Kilovolt : IUnit, IElectricPotentialUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Kilovolt";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "kV";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.ElectricPotential;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Kilo;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Kilovolt() { }
+
+};
+
+/// <summary>
+/// Kilohm - 1000 ohms.
+/// </summary>
+public sealed record Kilohm : IUnit, IElectricResistanceUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Kilohm";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "kΩ";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.ElectricResistance;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Kilo;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Kilohm() { }
+
+};
+
+/// <summary>
+/// Megohm - 1e6 ohms.
+/// </summary>
+public sealed record Megohm : IUnit, IElectricResistanceUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Megohm";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "MΩ";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.ElectricResistance;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Mega;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Megohm() { }
+
+};
+
+/// <summary>
+/// Microfarad - 1e-6 farads.
+/// </summary>
+public sealed record Microfarad : IUnit, IElectricCapacitanceUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Microfarad";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "μF";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.ElectricCapacitance;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Micro;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Microfarad() { }
+
+};
+
+/// <summary>
+/// Nanofarad - 1e-9 farads.
+/// </summary>
+public sealed record Nanofarad : IUnit, IElectricCapacitanceUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Nanofarad";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "nF";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.ElectricCapacitance;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Nano;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Nanofarad() { }
+
+};
+
+/// <summary>
+/// Picofarad - 1e-12 farads.
+/// </summary>
+public sealed record Picofarad : IUnit, IElectricCapacitanceUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Picofarad";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "pF";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.ElectricCapacitance;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Pico;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Picofarad() { }
+
+};
+
+/// <summary>
+/// Ampere-hour - 3600 coulombs of electric charge.
+/// </summary>
+public sealed record AmpereHour : IUnit, IElectricChargeUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "AmpereHour";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "Ah";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.ElectricCharge;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => AmpereHourToCoulombs;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public AmpereHour() { }
+
+};
+
+/// <summary>
 /// Radians per second - SI derived unit of angular velocity.
 /// </summary>
 public sealed record RadiansPerSecond : IUnit, IAngularVelocityUnit
@@ -2221,6 +3593,62 @@ public sealed record Hertz : IUnit, IFrequencyUnit
 };
 
 /// <summary>
+/// Kilohertz - 1000 hertz.
+/// </summary>
+public sealed record Kilohertz : IUnit, IFrequencyUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Kilohertz";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "kHz";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Frequency;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Kilo;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Kilohertz() { }
+
+};
+
+/// <summary>
+/// Megahertz - 1e6 hertz.
+/// </summary>
+public sealed record Megahertz : IUnit, IFrequencyUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Megahertz";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "MHz";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Frequency;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Mega;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Megahertz() { }
+
+};
+
+/// <summary>
 /// Candela - SI base unit of luminous intensity.
 /// </summary>
 public sealed record Candela : IUnit, ILuminousIntensityUnit
@@ -2329,6 +3757,62 @@ public sealed record Diopter : IUnit, IOpticalPowerUnit
 
 	/// <summary>Initializes a new instance of the unit.</summary>
 	public Diopter() { }
+
+};
+
+/// <summary>
+/// Millicandela - 0.001 candelas.
+/// </summary>
+public sealed record Millicandela : IUnit, ILuminousIntensityUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Millicandela";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "mcd";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.LuminousIntensity;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Milli;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Millicandela() { }
+
+};
+
+/// <summary>
+/// Foot-candle - Imperial unit of illuminance (lumen per square foot).
+/// </summary>
+public sealed record FootCandle : IUnit, IIlluminanceUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "FootCandle";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "fc";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Imperial;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Illuminance;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => FootCandleToLux;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public FootCandle() { }
 
 };
 
@@ -2473,6 +3957,118 @@ public sealed record CoulombPerKilogram : IUnit, IExposureUnit
 };
 
 /// <summary>
+/// Curie - traditional unit of radioactive activity.
+/// </summary>
+public sealed record Curie : IUnit, IRadioactiveActivityUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Curie";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "Ci";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.RadioactiveActivity;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => CurieToBecquerels;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Curie() { }
+
+};
+
+/// <summary>
+/// Rad - traditional unit of absorbed dose (0.01 Gy).
+/// </summary>
+public sealed record Rad : IUnit, IAbsorbedDoseUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Rad";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "rad";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.AbsorbedDose;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => RadToGrays;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Rad() { }
+
+};
+
+/// <summary>
+/// Rem - traditional unit of equivalent dose (0.01 Sv).
+/// </summary>
+public sealed record Rem : IUnit, IEquivalentDoseUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Rem";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "rem";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.EquivalentDose;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => RemToSieverts;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Rem() { }
+
+};
+
+/// <summary>
+/// Roentgen - traditional unit of ionizing radiation exposure.
+/// </summary>
+public sealed record Roentgen : IUnit, IExposureUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Roentgen";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "R";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Exposure;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => RoentgenToCoulombsPerKilogram;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Roentgen() { }
+
+};
+
+/// <summary>
 /// Kilogram per cubic meter - SI derived unit of density.
 /// </summary>
 public sealed record KilogramPerCubicMeter : IUnit, IDensityUnit
@@ -2497,6 +4093,62 @@ public sealed record KilogramPerCubicMeter : IUnit, IDensityUnit
 
 	/// <summary>Initializes a new instance of the unit.</summary>
 	public KilogramPerCubicMeter() { }
+
+};
+
+/// <summary>
+/// Gram per cubic centimeter - 1000 kg/m³.
+/// </summary>
+public sealed record GramPerCubicCentimeter : IUnit, IDensityUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "GramPerCubicCentimeter";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "g/cm³";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Density;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => GramPerCubicCentimeterToKilogramPerCubicMeter;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public GramPerCubicCentimeter() { }
+
+};
+
+/// <summary>
+/// Gram per liter - equal to one kilogram per cubic meter.
+/// </summary>
+public sealed record GramPerLiter : IUnit, IDensityUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "GramPerLiter";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "g/L";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Density;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => GramPerLiterToKilogramPerCubicMeter;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public GramPerLiter() { }
 
 };
 
@@ -2553,6 +4205,118 @@ public sealed record Molar : IUnit, IConcentrationUnit
 
 	/// <summary>Initializes a new instance of the unit.</summary>
 	public Molar() { }
+
+};
+
+/// <summary>
+/// Kilomole - 1000 moles.
+/// </summary>
+public sealed record Kilomole : IUnit, IAmountOfSubstanceUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Kilomole";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "kmol";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.AmountOfSubstance;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Kilo;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Kilomole() { }
+
+};
+
+/// <summary>
+/// Millimole - 0.001 moles.
+/// </summary>
+public sealed record Millimole : IUnit, IAmountOfSubstanceUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Millimole";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "mmol";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.AmountOfSubstance;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MetricMagnitudes.Milli;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Millimole() { }
+
+};
+
+/// <summary>
+/// Millimolar - 0.001 moles per liter (1 mol/m³).
+/// </summary>
+public sealed record Millimolar : IUnit, IConcentrationUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Millimolar";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "mM";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Concentration;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MillimolarToMolePerCubicMeter;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Millimolar() { }
+
+};
+
+/// <summary>
+/// Micromolar - 1e-6 moles per liter (0.001 mol/m³).
+/// </summary>
+public sealed record Micromolar : IUnit, IConcentrationUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Micromolar";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "μM";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.SIDerived;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.Concentration;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => MicromolarToMolePerCubicMeter;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Micromolar() { }
 
 };
 
@@ -2781,6 +4545,62 @@ public sealed record NewtonPerMeter : IUnit, ISurfaceTensionUnit
 };
 
 /// <summary>
+/// Centipoise - 0.001 pascal seconds (viscosity of water at 20°C ≈ 1 cP).
+/// </summary>
+public sealed record Centipoise : IUnit, IDynamicViscosityUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Centipoise";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "cP";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.CGS;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.DynamicViscosity;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => CentipoiseToPascalSecond;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Centipoise() { }
+
+};
+
+/// <summary>
+/// Dyne per centimeter - CGS unit of surface tension.
+/// </summary>
+public sealed record DynePerCentimeter : IUnit, ISurfaceTensionUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "DynePerCentimeter";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "dyn/cm";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.CGS;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.SurfaceTension;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => DynePerCentimeterToNewtonPerMeter;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public DynePerCentimeter() { }
+
+};
+
+/// <summary>
 /// Kilogram per mole - SI derived unit of molar mass.
 /// </summary>
 public sealed record KilogramPerMole : IUnit, IMolarMassUnit
@@ -2949,6 +4769,90 @@ public sealed record KilojoulePerMole : IUnit, IMolarEnergyUnit
 };
 
 /// <summary>
+/// Calorie per mole - thermochemical calorie per mole.
+/// </summary>
+public sealed record CaloriePerMole : IUnit, IMolarEnergyUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "CaloriePerMole";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "cal/mol";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.MolarEnergy;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => CaloriePerMoleToJoulePerMole;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public CaloriePerMole() { }
+
+};
+
+/// <summary>
+/// Enzyme unit - one micromole of substrate per minute.
+/// </summary>
+public sealed record EnzymeUnit : IUnit, ICatalyticActivityUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "EnzymeUnit";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "U";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Other;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.CatalyticActivity;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => EnzymeUnitToKatals;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public EnzymeUnit() { }
+
+};
+
+/// <summary>
+/// Dalton - molar mass numerically equal to one gram per mole.
+/// </summary>
+public sealed record Dalton : IUnit, IMolarMassUnit
+{
+	/// <summary>Gets the full name of the unit.</summary>
+	public string Name => "Dalton";
+
+	/// <summary>Gets the symbol/abbreviation of the unit.</summary>
+	public string Symbol => "Da";
+
+	/// <summary>Gets the unit system this unit belongs to.</summary>
+	public UnitSystem System => UnitSystem.Atomic;
+
+	/// <summary>Gets the physical dimension this unit measures.</summary>
+	public DimensionInfo Dimension => PhysicalDimensions.MolarMass;
+
+	/// <summary>Gets the multiplication factor used in the to-base affine conversion.</summary>
+	public double ToBaseFactor => GramPerMoleToKilogramPerMole;
+
+	/// <summary>Gets the additive offset used in the to-base affine conversion.</summary>
+	public double ToBaseOffset => 0d;
+
+	/// <summary>Initializes a new instance of the unit.</summary>
+	public Dalton() { }
+
+};
+
+/// <summary>
 /// Watt per square meter - SI derived unit of irradiance and sound intensity.
 /// </summary>
 public sealed record WattPerSquareMeter : IUnit, IIrradianceUnit
@@ -3009,14 +4913,23 @@ public sealed record PascalSecondPerMeter : IUnit, IAcousticImpedanceUnit
 /// types accept these on their typed <c>In(...)</c> methods.
 /// </summary>
 public static class Units{
+	/// <summary>Singleton <c>Acre</c> instance.</summary>
+	public static readonly Acre Acre = new Acre();
+
 	/// <summary>Singleton <c>Ampere</c> instance.</summary>
 	public static readonly Ampere Ampere = new Ampere();
+
+	/// <summary>Singleton <c>AmpereHour</c> instance.</summary>
+	public static readonly AmpereHour AmpereHour = new AmpereHour();
 
 	/// <summary>Singleton <c>Angstrom</c> instance.</summary>
 	public static readonly Angstrom Angstrom = new Angstrom();
 
 	/// <summary>Singleton <c>Atmosphere</c> instance.</summary>
 	public static readonly Atmosphere Atmosphere = new Atmosphere();
+
+	/// <summary>Singleton <c>AtomicMassUnit</c> instance.</summary>
+	public static readonly AtomicMassUnit AtomicMassUnit = new AtomicMassUnit();
 
 	/// <summary>Singleton <c>Bar</c> instance.</summary>
 	public static readonly Bar Bar = new Bar();
@@ -3027,8 +4940,14 @@ public static class Units{
 	/// <summary>Singleton <c>Becquerel</c> instance.</summary>
 	public static readonly Becquerel Becquerel = new Becquerel();
 
+	/// <summary>Singleton <c>Btu</c> instance.</summary>
+	public static readonly Btu Btu = new Btu();
+
 	/// <summary>Singleton <c>Calorie</c> instance.</summary>
 	public static readonly Calorie Calorie = new Calorie();
+
+	/// <summary>Singleton <c>CaloriePerMole</c> instance.</summary>
+	public static readonly CaloriePerMole CaloriePerMole = new CaloriePerMole();
 
 	/// <summary>Singleton <c>Candela</c> instance.</summary>
 	public static readonly Candela Candela = new Candela();
@@ -3039,17 +4958,35 @@ public static class Units{
 	/// <summary>Singleton <c>Centimeter</c> instance.</summary>
 	public static readonly Centimeter Centimeter = new Centimeter();
 
+	/// <summary>Singleton <c>Centipoise</c> instance.</summary>
+	public static readonly Centipoise Centipoise = new Centipoise();
+
 	/// <summary>Singleton <c>Coulomb</c> instance.</summary>
 	public static readonly Coulomb Coulomb = new Coulomb();
 
 	/// <summary>Singleton <c>CoulombPerKilogram</c> instance.</summary>
 	public static readonly CoulombPerKilogram CoulombPerKilogram = new CoulombPerKilogram();
 
+	/// <summary>Singleton <c>CubicCentimeter</c> instance.</summary>
+	public static readonly CubicCentimeter CubicCentimeter = new CubicCentimeter();
+
+	/// <summary>Singleton <c>CubicFoot</c> instance.</summary>
+	public static readonly CubicFoot CubicFoot = new CubicFoot();
+
+	/// <summary>Singleton <c>CubicInch</c> instance.</summary>
+	public static readonly CubicInch CubicInch = new CubicInch();
+
 	/// <summary>Singleton <c>CubicMeter</c> instance.</summary>
 	public static readonly CubicMeter CubicMeter = new CubicMeter();
 
 	/// <summary>Singleton <c>CubicMeterPerSecond</c> instance.</summary>
 	public static readonly CubicMeterPerSecond CubicMeterPerSecond = new CubicMeterPerSecond();
+
+	/// <summary>Singleton <c>Curie</c> instance.</summary>
+	public static readonly Curie Curie = new Curie();
+
+	/// <summary>Singleton <c>Dalton</c> instance.</summary>
+	public static readonly Dalton Dalton = new Dalton();
 
 	/// <summary>Singleton <c>Day</c> instance.</summary>
 	public static readonly Day Day = new Day();
@@ -3063,8 +5000,20 @@ public static class Units{
 	/// <summary>Singleton <c>Diopter</c> instance.</summary>
 	public static readonly Diopter Diopter = new Diopter();
 
+	/// <summary>Singleton <c>Dyne</c> instance.</summary>
+	public static readonly Dyne Dyne = new Dyne();
+
+	/// <summary>Singleton <c>DynePerCentimeter</c> instance.</summary>
+	public static readonly DynePerCentimeter DynePerCentimeter = new DynePerCentimeter();
+
 	/// <summary>Singleton <c>ElectronVolt</c> instance.</summary>
 	public static readonly ElectronVolt ElectronVolt = new ElectronVolt();
+
+	/// <summary>Singleton <c>EnzymeUnit</c> instance.</summary>
+	public static readonly EnzymeUnit EnzymeUnit = new EnzymeUnit();
+
+	/// <summary>Singleton <c>Erg</c> instance.</summary>
+	public static readonly Erg Erg = new Erg();
 
 	/// <summary>Singleton <c>Fahrenheit</c> instance.</summary>
 	public static readonly Fahrenheit Fahrenheit = new Fahrenheit();
@@ -3072,8 +5021,14 @@ public static class Units{
 	/// <summary>Singleton <c>Farad</c> instance.</summary>
 	public static readonly Farad Farad = new Farad();
 
+	/// <summary>Singleton <c>FeetPerSecond</c> instance.</summary>
+	public static readonly FeetPerSecond FeetPerSecond = new FeetPerSecond();
+
 	/// <summary>Singleton <c>Foot</c> instance.</summary>
 	public static readonly Foot Foot = new Foot();
+
+	/// <summary>Singleton <c>FootCandle</c> instance.</summary>
+	public static readonly FootCandle FootCandle = new FootCandle();
 
 	/// <summary>Singleton <c>Gallon</c> instance.</summary>
 	public static readonly Gallon Gallon = new Gallon();
@@ -3081,14 +5036,26 @@ public static class Units{
 	/// <summary>Singleton <c>Gauss</c> instance.</summary>
 	public static readonly Gauss Gauss = new Gauss();
 
+	/// <summary>Singleton <c>Gradian</c> instance.</summary>
+	public static readonly Gradian Gradian = new Gradian();
+
 	/// <summary>Singleton <c>Gram</c> instance.</summary>
 	public static readonly Gram Gram = new Gram();
+
+	/// <summary>Singleton <c>GramPerCubicCentimeter</c> instance.</summary>
+	public static readonly GramPerCubicCentimeter GramPerCubicCentimeter = new GramPerCubicCentimeter();
+
+	/// <summary>Singleton <c>GramPerLiter</c> instance.</summary>
+	public static readonly GramPerLiter GramPerLiter = new GramPerLiter();
 
 	/// <summary>Singleton <c>GramPerMole</c> instance.</summary>
 	public static readonly GramPerMole GramPerMole = new GramPerMole();
 
 	/// <summary>Singleton <c>Gray</c> instance.</summary>
 	public static readonly Gray Gray = new Gray();
+
+	/// <summary>Singleton <c>Hectare</c> instance.</summary>
+	public static readonly Hectare Hectare = new Hectare();
 
 	/// <summary>Singleton <c>Henry</c> instance.</summary>
 	public static readonly Henry Henry = new Henry();
@@ -3101,6 +5068,9 @@ public static class Units{
 
 	/// <summary>Singleton <c>Hour</c> instance.</summary>
 	public static readonly Hour Hour = new Hour();
+
+	/// <summary>Singleton <c>ImperialGallon</c> instance.</summary>
+	public static readonly ImperialGallon ImperialGallon = new ImperialGallon();
 
 	/// <summary>Singleton <c>Inch</c> instance.</summary>
 	public static readonly Inch Inch = new Inch();
@@ -3123,6 +5093,12 @@ public static class Units{
 	/// <summary>Singleton <c>Kelvin</c> instance.</summary>
 	public static readonly Kelvin Kelvin = new Kelvin();
 
+	/// <summary>Singleton <c>Kiloampere</c> instance.</summary>
+	public static readonly Kiloampere Kiloampere = new Kiloampere();
+
+	/// <summary>Singleton <c>Kilocalorie</c> instance.</summary>
+	public static readonly Kilocalorie Kilocalorie = new Kilocalorie();
+
 	/// <summary>Singleton <c>Kilogram</c> instance.</summary>
 	public static readonly Kilogram Kilogram = new Kilogram();
 
@@ -3141,6 +5117,15 @@ public static class Units{
 	/// <summary>Singleton <c>KilogramPerSecond</c> instance.</summary>
 	public static readonly KilogramPerSecond KilogramPerSecond = new KilogramPerSecond();
 
+	/// <summary>Singleton <c>Kilohertz</c> instance.</summary>
+	public static readonly Kilohertz Kilohertz = new Kilohertz();
+
+	/// <summary>Singleton <c>Kilohm</c> instance.</summary>
+	public static readonly Kilohm Kilohm = new Kilohm();
+
+	/// <summary>Singleton <c>Kilojoule</c> instance.</summary>
+	public static readonly Kilojoule Kilojoule = new Kilojoule();
+
 	/// <summary>Singleton <c>KilojoulePerMole</c> instance.</summary>
 	public static readonly KilojoulePerMole KilojoulePerMole = new KilojoulePerMole();
 
@@ -3150,8 +5135,26 @@ public static class Units{
 	/// <summary>Singleton <c>KilometersPerHour</c> instance.</summary>
 	public static readonly KilometersPerHour KilometersPerHour = new KilometersPerHour();
 
+	/// <summary>Singleton <c>Kilomole</c> instance.</summary>
+	public static readonly Kilomole Kilomole = new Kilomole();
+
+	/// <summary>Singleton <c>Kilonewton</c> instance.</summary>
+	public static readonly Kilonewton Kilonewton = new Kilonewton();
+
+	/// <summary>Singleton <c>Kilopascal</c> instance.</summary>
+	public static readonly Kilopascal Kilopascal = new Kilopascal();
+
+	/// <summary>Singleton <c>Kilovolt</c> instance.</summary>
+	public static readonly Kilovolt Kilovolt = new Kilovolt();
+
+	/// <summary>Singleton <c>Kilowatt</c> instance.</summary>
+	public static readonly Kilowatt Kilowatt = new Kilowatt();
+
 	/// <summary>Singleton <c>KilowattHour</c> instance.</summary>
 	public static readonly KilowattHour KilowattHour = new KilowattHour();
+
+	/// <summary>Singleton <c>Knot</c> instance.</summary>
+	public static readonly Knot Knot = new Knot();
 
 	/// <summary>Singleton <c>Liter</c> instance.</summary>
 	public static readonly Liter Liter = new Liter();
@@ -3164,6 +5167,15 @@ public static class Units{
 
 	/// <summary>Singleton <c>Lux</c> instance.</summary>
 	public static readonly Lux Lux = new Lux();
+
+	/// <summary>Singleton <c>Megahertz</c> instance.</summary>
+	public static readonly Megahertz Megahertz = new Megahertz();
+
+	/// <summary>Singleton <c>Megawatt</c> instance.</summary>
+	public static readonly Megawatt Megawatt = new Megawatt();
+
+	/// <summary>Singleton <c>Megohm</c> instance.</summary>
+	public static readonly Megohm Megohm = new Megohm();
 
 	/// <summary>Singleton <c>Meter</c> instance.</summary>
 	public static readonly Meter Meter = new Meter();
@@ -3180,8 +5192,14 @@ public static class Units{
 	/// <summary>Singleton <c>MetersPerSecondSquared</c> instance.</summary>
 	public static readonly MetersPerSecondSquared MetersPerSecondSquared = new MetersPerSecondSquared();
 
+	/// <summary>Singleton <c>Microfarad</c> instance.</summary>
+	public static readonly Microfarad Microfarad = new Microfarad();
+
 	/// <summary>Singleton <c>Micrometer</c> instance.</summary>
 	public static readonly Micrometer Micrometer = new Micrometer();
+
+	/// <summary>Singleton <c>Micromolar</c> instance.</summary>
+	public static readonly Micromolar Micromolar = new Micromolar();
 
 	/// <summary>Singleton <c>Microsecond</c> instance.</summary>
 	public static readonly Microsecond Microsecond = new Microsecond();
@@ -3192,11 +5210,26 @@ public static class Units{
 	/// <summary>Singleton <c>MilesPerHour</c> instance.</summary>
 	public static readonly MilesPerHour MilesPerHour = new MilesPerHour();
 
+	/// <summary>Singleton <c>Milliampere</c> instance.</summary>
+	public static readonly Milliampere Milliampere = new Milliampere();
+
+	/// <summary>Singleton <c>Millicandela</c> instance.</summary>
+	public static readonly Millicandela Millicandela = new Millicandela();
+
 	/// <summary>Singleton <c>Milliliter</c> instance.</summary>
 	public static readonly Milliliter Milliliter = new Milliliter();
 
 	/// <summary>Singleton <c>Millimeter</c> instance.</summary>
 	public static readonly Millimeter Millimeter = new Millimeter();
+
+	/// <summary>Singleton <c>Millimolar</c> instance.</summary>
+	public static readonly Millimolar Millimolar = new Millimolar();
+
+	/// <summary>Singleton <c>Millimole</c> instance.</summary>
+	public static readonly Millimole Millimole = new Millimole();
+
+	/// <summary>Singleton <c>Milliradian</c> instance.</summary>
+	public static readonly Milliradian Milliradian = new Milliradian();
 
 	/// <summary>Singleton <c>Millisecond</c> instance.</summary>
 	public static readonly Millisecond Millisecond = new Millisecond();
@@ -3213,8 +5246,17 @@ public static class Units{
 	/// <summary>Singleton <c>MolePerCubicMeterSecond</c> instance.</summary>
 	public static readonly MolePerCubicMeterSecond MolePerCubicMeterSecond = new MolePerCubicMeterSecond();
 
+	/// <summary>Singleton <c>Nanofarad</c> instance.</summary>
+	public static readonly Nanofarad Nanofarad = new Nanofarad();
+
 	/// <summary>Singleton <c>Nanometer</c> instance.</summary>
 	public static readonly Nanometer Nanometer = new Nanometer();
+
+	/// <summary>Singleton <c>Nanosecond</c> instance.</summary>
+	public static readonly Nanosecond Nanosecond = new Nanosecond();
+
+	/// <summary>Singleton <c>NauticalMile</c> instance.</summary>
+	public static readonly NauticalMile NauticalMile = new NauticalMile();
 
 	/// <summary>Singleton <c>Newton</c> instance.</summary>
 	public static readonly Newton Newton = new Newton();
@@ -3234,6 +5276,12 @@ public static class Units{
 	/// <summary>Singleton <c>Ounce</c> instance.</summary>
 	public static readonly Ounce Ounce = new Ounce();
 
+	/// <summary>Singleton <c>PartsPerBillion</c> instance.</summary>
+	public static readonly PartsPerBillion PartsPerBillion = new PartsPerBillion();
+
+	/// <summary>Singleton <c>PartsPerMillion</c> instance.</summary>
+	public static readonly PartsPerMillion PartsPerMillion = new PartsPerMillion();
+
 	/// <summary>Singleton <c>Pascal</c> instance.</summary>
 	public static readonly Pascal Pascal = new Pascal();
 
@@ -3246,6 +5294,12 @@ public static class Units{
 	/// <summary>Singleton <c>PerKelvin</c> instance.</summary>
 	public static readonly PerKelvin PerKelvin = new PerKelvin();
 
+	/// <summary>Singleton <c>PercentByWeight</c> instance.</summary>
+	public static readonly PercentByWeight PercentByWeight = new PercentByWeight();
+
+	/// <summary>Singleton <c>Picofarad</c> instance.</summary>
+	public static readonly Picofarad Picofarad = new Picofarad();
+
 	/// <summary>Singleton <c>Poise</c> instance.</summary>
 	public static readonly Poise Poise = new Poise();
 
@@ -3255,8 +5309,14 @@ public static class Units{
 	/// <summary>Singleton <c>PoundFoot</c> instance.</summary>
 	public static readonly PoundFoot PoundFoot = new PoundFoot();
 
+	/// <summary>Singleton <c>PoundForce</c> instance.</summary>
+	public static readonly PoundForce PoundForce = new PoundForce();
+
 	/// <summary>Singleton <c>Psi</c> instance.</summary>
 	public static readonly Psi Psi = new Psi();
+
+	/// <summary>Singleton <c>Rad</c> instance.</summary>
+	public static readonly Rad Rad = new Rad();
 
 	/// <summary>Singleton <c>Radian</c> instance.</summary>
 	public static readonly Radian Radian = new Radian();
@@ -3270,11 +5330,26 @@ public static class Units{
 	/// <summary>Singleton <c>RadiansPerSecondSquared</c> instance.</summary>
 	public static readonly RadiansPerSecondSquared RadiansPerSecondSquared = new RadiansPerSecondSquared();
 
+	/// <summary>Singleton <c>Rankine</c> instance.</summary>
+	public static readonly Rankine Rankine = new Rankine();
+
+	/// <summary>Singleton <c>Rem</c> instance.</summary>
+	public static readonly Rem Rem = new Rem();
+
+	/// <summary>Singleton <c>Revolution</c> instance.</summary>
+	public static readonly Revolution Revolution = new Revolution();
+
 	/// <summary>Singleton <c>RevolutionsPerMinute</c> instance.</summary>
 	public static readonly RevolutionsPerMinute RevolutionsPerMinute = new RevolutionsPerMinute();
 
+	/// <summary>Singleton <c>Roentgen</c> instance.</summary>
+	public static readonly Roentgen Roentgen = new Roentgen();
+
 	/// <summary>Singleton <c>Second</c> instance.</summary>
 	public static readonly Second Second = new Second();
+
+	/// <summary>Singleton <c>ShortTon</c> instance.</summary>
+	public static readonly ShortTon ShortTon = new ShortTon();
 
 	/// <summary>Singleton <c>Siemens</c> instance.</summary>
 	public static readonly Siemens Siemens = new Siemens();
@@ -3282,11 +5357,17 @@ public static class Units{
 	/// <summary>Singleton <c>Sievert</c> instance.</summary>
 	public static readonly Sievert Sievert = new Sievert();
 
+	/// <summary>Singleton <c>SquareCentimeter</c> instance.</summary>
+	public static readonly SquareCentimeter SquareCentimeter = new SquareCentimeter();
+
 	/// <summary>Singleton <c>SquareFoot</c> instance.</summary>
 	public static readonly SquareFoot SquareFoot = new SquareFoot();
 
 	/// <summary>Singleton <c>SquareInch</c> instance.</summary>
 	public static readonly SquareInch SquareInch = new SquareInch();
+
+	/// <summary>Singleton <c>SquareKilometer</c> instance.</summary>
+	public static readonly SquareKilometer SquareKilometer = new SquareKilometer();
 
 	/// <summary>Singleton <c>SquareMeter</c> instance.</summary>
 	public static readonly SquareMeter SquareMeter = new SquareMeter();
@@ -3294,14 +5375,35 @@ public static class Units{
 	/// <summary>Singleton <c>SquareMeterPerSecond</c> instance.</summary>
 	public static readonly SquareMeterPerSecond SquareMeterPerSecond = new SquareMeterPerSecond();
 
+	/// <summary>Singleton <c>SquareMile</c> instance.</summary>
+	public static readonly SquareMile SquareMile = new SquareMile();
+
+	/// <summary>Singleton <c>StandardGravity</c> instance.</summary>
+	public static readonly StandardGravity StandardGravity = new StandardGravity();
+
 	/// <summary>Singleton <c>Stokes</c> instance.</summary>
 	public static readonly Stokes Stokes = new Stokes();
+
+	/// <summary>Singleton <c>Stone</c> instance.</summary>
+	public static readonly Stone Stone = new Stone();
 
 	/// <summary>Singleton <c>Tesla</c> instance.</summary>
 	public static readonly Tesla Tesla = new Tesla();
 
 	/// <summary>Singleton <c>Ton</c> instance.</summary>
 	public static readonly Ton Ton = new Ton();
+
+	/// <summary>Singleton <c>Torr</c> instance.</summary>
+	public static readonly Torr Torr = new Torr();
+
+	/// <summary>Singleton <c>USFluidOunce</c> instance.</summary>
+	public static readonly USFluidOunce USFluidOunce = new USFluidOunce();
+
+	/// <summary>Singleton <c>USPint</c> instance.</summary>
+	public static readonly USPint USPint = new USPint();
+
+	/// <summary>Singleton <c>USQuart</c> instance.</summary>
+	public static readonly USQuart USQuart = new USQuart();
 
 	/// <summary>Singleton <c>Volt</c> instance.</summary>
 	public static readonly Volt Volt = new Volt();
@@ -3311,6 +5413,9 @@ public static class Units{
 
 	/// <summary>Singleton <c>Watt</c> instance.</summary>
 	public static readonly Watt Watt = new Watt();
+
+	/// <summary>Singleton <c>WattHour</c> instance.</summary>
+	public static readonly WattHour WattHour = new WattHour();
 
 	/// <summary>Singleton <c>WattPerMeterKelvin</c> instance.</summary>
 	public static readonly WattPerMeterKelvin WattPerMeterKelvin = new WattPerMeterKelvin();
@@ -3323,6 +5428,9 @@ public static class Units{
 
 	/// <summary>Singleton <c>Weber</c> instance.</summary>
 	public static readonly Weber Weber = new Weber();
+
+	/// <summary>Singleton <c>Week</c> instance.</summary>
+	public static readonly Week Week = new Week();
 
 	/// <summary>Singleton <c>Yard</c> instance.</summary>
 	public static readonly Yard Yard = new Yard();

--- a/Semantics.SourceGenerators/Generators/PhysicalConstantsGenerator.cs
+++ b/Semantics.SourceGenerators/Generators/PhysicalConstantsGenerator.cs
@@ -119,7 +119,10 @@ public class PhysicalConstantsGenerator : GeneratorBase<DomainsMetadata>
 					Name = $"{constant.Name}<T>",
 					BodyFactory = (body) =>
 					{
-						body.Write($" where T : struct, INumber<T> => T.CreateChecked({domainName}.{constant.Name});");
+						// PreciseNumber does not support T.CreateChecked conversion (its
+						// TryConvertToChecked throws NotSupportedException); To<T>() is the
+						// supported materialisation path.
+						body.Write($" where T : struct, INumber<T> => {domainName}.{constant.Name}.To<T>();");
 					},
 				});
 			}

--- a/Semantics.SourceGenerators/Metadata/conversions.json
+++ b/Semantics.SourceGenerators/Metadata/conversions.json
@@ -28,6 +28,11 @@
           "name": "AngstromToMeters",
           "description": "Angstrom to meter conversion: 1e-10 m/Å (exact by definition)",
           "value": "1e-10"
+        },
+        {
+          "name": "NauticalMileToMeters",
+          "description": "Nautical mile to meter conversion: 1852 m/nmi (exact by definition)",
+          "value": "1852"
         }
       ]
     },
@@ -54,6 +59,21 @@
           "name": "TonToKilograms",
           "description": "Metric ton to kilogram conversion: 1000 kg/t (exact by definition)",
           "value": "1000"
+        },
+        {
+          "name": "StoneToKilograms",
+          "description": "Stone to kilogram conversion: 6.35029318 kg/st (14 lb, exact)",
+          "value": "6.35029318"
+        },
+        {
+          "name": "ShortTonToKilograms",
+          "description": "Short ton to kilogram conversion: 907.18474 kg/ton (2000 lb, exact)",
+          "value": "907.18474"
+        },
+        {
+          "name": "AtomicMassUnitToKilograms",
+          "description": "Atomic mass unit to kilogram: 1.66053906660e-27 kg/u (2018 CODATA)",
+          "value": "1.66053906660e-27"
         }
       ]
     },
@@ -70,6 +90,41 @@
           "name": "GallonToCubicMeters",
           "description": "US gallon to cubic meter conversion: 0.003785411784 m³/gal (exact)",
           "value": "0.003785411784"
+        },
+        {
+          "name": "CubicCentimeterToCubicMeters",
+          "description": "Cubic centimeter to cubic meter: 1e-6 m³/cm³ (exact by definition)",
+          "value": "1e-6"
+        },
+        {
+          "name": "CubicFootToCubicMeters",
+          "description": "Cubic foot to cubic meter: 0.028316846592 m³/ft³ (exact)",
+          "value": "0.028316846592"
+        },
+        {
+          "name": "CubicInchToCubicMeters",
+          "description": "Cubic inch to cubic meter: 1.6387064e-5 m³/in³ (exact)",
+          "value": "1.6387064e-5"
+        },
+        {
+          "name": "ImperialGallonToCubicMeters",
+          "description": "Imperial gallon to cubic meter: 0.00454609 m³/imp gal (exact by definition)",
+          "value": "0.00454609"
+        },
+        {
+          "name": "USQuartToCubicMeters",
+          "description": "US liquid quart to cubic meter: 0.000946352946 m³/qt (exact)",
+          "value": "0.000946352946"
+        },
+        {
+          "name": "USPintToCubicMeters",
+          "description": "US liquid pint to cubic meter: 0.000473176473 m³/pt (exact)",
+          "value": "0.000473176473"
+        },
+        {
+          "name": "USFluidOunceToCubicMeters",
+          "description": "US fluid ounce to cubic meter: 2.95735295625e-5 m³/fl oz (exact)",
+          "value": "2.95735295625e-5"
         }
       ]
     },
@@ -96,6 +151,11 @@
           "name": "YearToSeconds",
           "description": "Year to second conversion: 31557600 s/year (365.25 days, exact)",
           "value": "31557600"
+        },
+        {
+          "name": "WeekToSeconds",
+          "description": "Week to second conversion: 604800 s/wk (exact)",
+          "value": "604800"
         }
       ]
     },
@@ -110,13 +170,13 @@
         },
         {
           "name": "FahrenheitScale",
-          "description": "Fahrenheit degree scale factor: 9/5 = 1.8 (exact)",
-          "value": "1.8"
+          "description": "Fahrenheit-to-Kelvin degree scale factor: 5/9 (exact)",
+          "value": "0.5555555555555556"
         },
         {
           "name": "FahrenheitToKelvinOffset",
-          "description": "Fahrenheit to Kelvin absolute offset: -459.67 K (exact)",
-          "value": "-459.67"
+          "description": "Fahrenheit to Kelvin affine offset: 459.67 × 5/9 ≈ 255.372 K (exact)",
+          "value": "255.37222222222223"
         }
       ]
     },
@@ -128,6 +188,16 @@
           "name": "DegreeToRadians",
           "description": "Degree to radian conversion: π/180 rad/° (exact)",
           "value": "0.017453292519943295769236907684886127134428718885417254560971914401710091146034494436822415696345097379101040706699150667990539631694451077627806983"
+        },
+        {
+          "name": "GradianToRadians",
+          "description": "Gradian to radian conversion: π/200 rad/grad (exact)",
+          "value": "0.015707963267948966"
+        },
+        {
+          "name": "RevolutionToRadians",
+          "description": "Revolution to radian conversion: 2π rad/rev (exact)",
+          "value": "6.283185307179586"
         }
       ]
     },
@@ -154,6 +224,26 @@
           "name": "ElectronVoltToJoules",
           "description": "Electron volt to joule conversion: 1.602176634e-19 J/eV (exact, based on elementary charge)",
           "value": "1.602176634e-19"
+        },
+        {
+          "name": "KilocalorieToJoules",
+          "description": "Kilocalorie to joule conversion: 4184 J/kcal (exact, thermochemical)",
+          "value": "4184"
+        },
+        {
+          "name": "WattHourToJoules",
+          "description": "Watt-hour to joule conversion: 3600 J/Wh (exact)",
+          "value": "3600"
+        },
+        {
+          "name": "ErgToJoules",
+          "description": "Erg to joule conversion: 1e-7 J/erg (exact by definition)",
+          "value": "1e-7"
+        },
+        {
+          "name": "BtuToJoules",
+          "description": "British thermal unit (IT) to joule conversion: 1055.05585262 J/BTU (exact)",
+          "value": "1055.05585262"
         }
       ]
     },
@@ -175,6 +265,11 @@
           "name": "PsiToPascals",
           "description": "PSI to pascal conversion: 6894.757293168361 Pa/psi (exact)",
           "value": "6894.757293168361"
+        },
+        {
+          "name": "TorrToPascals",
+          "description": "Torr to pascal conversion: 101325/760 ≈ 133.322 Pa/Torr (exact)",
+          "value": "133.32236842105263"
         }
       ]
     },
@@ -196,6 +291,31 @@
           "name": "BarnToSquareMeters",
           "description": "Barn to square meter conversion: 1e-28 m² (exact by definition)",
           "value": "1e-28"
+        },
+        {
+          "name": "SquareKilometerToSquareMeters",
+          "description": "Square kilometer to square meter: 1e6 m²/km² (exact by definition)",
+          "value": "1e6"
+        },
+        {
+          "name": "SquareCentimeterToSquareMeters",
+          "description": "Square centimeter to square meter: 1e-4 m²/cm² (exact by definition)",
+          "value": "1e-4"
+        },
+        {
+          "name": "SquareMileToSquareMeters",
+          "description": "Square mile to square meter: 2589988.110336 m²/mi² (exact)",
+          "value": "2589988.110336"
+        },
+        {
+          "name": "HectareToSquareMeters",
+          "description": "Hectare to square meter: 10000 m²/ha (exact by definition)",
+          "value": "10000"
+        },
+        {
+          "name": "AcreToSquareMeters",
+          "description": "Acre to square meter: 4046.8564224 m²/ac (exact)",
+          "value": "4046.8564224"
         }
       ]
     },
@@ -212,6 +332,16 @@
           "name": "MilesPerHourToMetersPerSecond",
           "description": "Miles per hour to meters per second conversion: 0.44704 m/s per mph (exact)",
           "value": "0.44704"
+        },
+        {
+          "name": "FeetPerSecondToMetersPerSecond",
+          "description": "Feet per second to meters per second: 0.3048 m/s per ft/s (exact)",
+          "value": "0.3048"
+        },
+        {
+          "name": "KnotToMetersPerSecond",
+          "description": "Knot to meters per second: 1852/3600 ≈ 0.514444 m/s per kn (exact)",
+          "value": "0.5144444444444445"
         }
       ]
     },
@@ -245,6 +375,16 @@
           "name": "MolarToCubicMeter",
           "description": "Molar to cubic meter concentration conversion: 1000.0 mol/m³ per mol/L (exact)",
           "value": "1000.0"
+        },
+        {
+          "name": "MillimolarToMolePerCubicMeter",
+          "description": "Millimolar to mole per cubic meter: 1 mol/m³ per mM (exact)",
+          "value": "1.0"
+        },
+        {
+          "name": "MicromolarToMolePerCubicMeter",
+          "description": "Micromolar to mole per cubic meter: 0.001 mol/m³ per μM (exact)",
+          "value": "0.001"
         }
       ]
     },
@@ -266,6 +406,26 @@
           "name": "LiterPerSecondToCubicMeterPerSecond",
           "description": "Liter per second to cubic meter per second: 0.001 m³/s per L/s (exact by definition)",
           "value": "0.001"
+        },
+        {
+          "name": "CentipoiseToPascalSecond",
+          "description": "Centipoise to pascal second: 0.001 Pa·s per cP (exact by definition)",
+          "value": "0.001"
+        },
+        {
+          "name": "DynePerCentimeterToNewtonPerMeter",
+          "description": "Dyne per centimeter to newton per meter: 0.001 N/m per dyn/cm (exact)",
+          "value": "0.001"
+        },
+        {
+          "name": "GramPerCubicCentimeterToKilogramPerCubicMeter",
+          "description": "Gram per cubic centimeter to kilogram per cubic meter: 1000 kg/m³ per g/cm³ (exact)",
+          "value": "1000"
+        },
+        {
+          "name": "GramPerLiterToKilogramPerCubicMeter",
+          "description": "Gram per liter to kilogram per cubic meter: 1 kg/m³ per g/L (exact)",
+          "value": "1.0"
         }
       ]
     },
@@ -277,6 +437,11 @@
           "name": "GaussToTesla",
           "description": "Gauss to Tesla: 1e-4 T per G (exact by definition)",
           "value": "1e-4"
+        },
+        {
+          "name": "AmpereHourToCoulombs",
+          "description": "Ampere-hour to coulomb conversion: 3600 C/Ah (exact)",
+          "value": "3600"
         }
       ]
     },
@@ -293,6 +458,101 @@
           "name": "KilojoulePerMoleToJoulePerMole",
           "description": "Kilojoule per mole to joule per mole: 1000 J/mol per kJ/mol (exact by definition)",
           "value": "1000"
+        },
+        {
+          "name": "CaloriePerMoleToJoulePerMole",
+          "description": "Calorie per mole to joule per mole: 4.184 J/mol per cal/mol (exact, thermochemical)",
+          "value": "4.184"
+        },
+        {
+          "name": "EnzymeUnitToKatals",
+          "description": "Enzyme unit (1 μmol/min) to katal: 1/6e7 ≈ 1.6667e-8 kat/U (exact)",
+          "value": "1.6666666666666667e-8"
+        }
+      ]
+    },
+    {
+      "category": "Acceleration",
+      "description": "Acceleration unit conversion factors",
+      "factors": [
+        {
+          "name": "StandardGravityToMetersPerSecondSquared",
+          "description": "Standard gravity to meters per second squared: 9.80665 m/s² per g (exact by definition)",
+          "value": "9.80665"
+        }
+      ]
+    },
+    {
+      "category": "Force",
+      "description": "Force unit conversion factors",
+      "factors": [
+        {
+          "name": "DyneToNewtons",
+          "description": "Dyne to newton conversion: 1e-5 N/dyn (exact by definition)",
+          "value": "1e-5"
+        },
+        {
+          "name": "PoundForceToNewtons",
+          "description": "Pound-force to newton conversion: 4.4482216152605 N/lbf (exact)",
+          "value": "4.4482216152605"
+        }
+      ]
+    },
+    {
+      "category": "Radiation",
+      "description": "Radiological unit conversion factors",
+      "factors": [
+        {
+          "name": "CurieToBecquerels",
+          "description": "Curie to becquerel conversion: 3.7e10 Bq/Ci (exact by definition)",
+          "value": "3.7e10"
+        },
+        {
+          "name": "RadToGrays",
+          "description": "Rad to gray conversion: 0.01 Gy/rad (exact by definition)",
+          "value": "0.01"
+        },
+        {
+          "name": "RemToSieverts",
+          "description": "Rem to sievert conversion: 0.01 Sv/rem (exact by definition)",
+          "value": "0.01"
+        },
+        {
+          "name": "RoentgenToCoulombsPerKilogram",
+          "description": "Roentgen to coulomb per kilogram: 2.58e-4 C/kg per R (exact by definition)",
+          "value": "2.58e-4"
+        }
+      ]
+    },
+    {
+      "category": "Photometry",
+      "description": "Photometric unit conversion factors",
+      "factors": [
+        {
+          "name": "FootCandleToLux",
+          "description": "Foot-candle to lux conversion: 1/0.09290304 ≈ 10.7639 lx/fc (exact)",
+          "value": "10.763910416709722"
+        }
+      ]
+    },
+    {
+      "category": "Ratio",
+      "description": "Dimensionless ratio conversion factors",
+      "factors": [
+        {
+          "name": "PartsPerMillionToRatio",
+          "description": "Parts per million to ratio: 1e-6 (exact by definition)",
+          "value": "1e-6"
+        },
+        {
+          "name": "PartsPerBillionToRatio",
+          "description": "Parts per billion to ratio: 1e-9 (exact by definition)",
+          "value": "1e-9"
+        },
+        {
+          "name": "PercentByWeightToRatio",
+          "description": "Percent by weight to mass-fraction ratio: 0.01 (exact by definition)",
+          "value": "0.01"
         }
       ]
     }

--- a/Semantics.SourceGenerators/Metadata/dimensions.json
+++ b/Semantics.SourceGenerators/Metadata/dimensions.json
@@ -4,7 +4,7 @@
       "name": "Dimensionless",
       "symbol": "1",
       "dimensionalFormula": {},
-      "availableUnits": ["Dimensionless", "Radian", "Degree"],
+      "availableUnits": ["Dimensionless", "Radian", "Degree", "Gradian", "Revolution", "Milliradian", "PartsPerMillion", "PartsPerBillion", "PercentByWeight"],
       "quantities": {
         "vector0": {
           "base": "Ratio",
@@ -29,7 +29,7 @@
       "availableUnits": [
         "Meter", "Kilometer", "Centimeter", "Millimeter",
         "Micrometer", "Nanometer", "Angstrom",
-        "Foot", "Inch", "Yard", "Mile"
+        "Foot", "Inch", "Yard", "Mile", "NauticalMile"
       ],
       "quantities": {
         "vector0": {
@@ -78,7 +78,7 @@
       "name": "Mass",
       "symbol": "M",
       "dimensionalFormula": { "mass": 1 },
-      "availableUnits": ["Kilogram", "Gram", "Ton", "Pound", "Ounce"],
+      "availableUnits": ["Kilogram", "Gram", "Ton", "Pound", "Ounce", "Stone", "ShortTon", "AtomicMassUnit"],
       "quantities": {
         "vector0": {
           "base": "Mass",
@@ -101,7 +101,7 @@
       "dimensionalFormula": { "time": 1 },
       "availableUnits": [
         "Second", "Millisecond", "Microsecond",
-        "Minute", "Hour", "Day", "Year"
+        "Minute", "Hour", "Day", "Year", "Week", "Nanosecond"
       ],
       "quantities": {
         "vector0": {
@@ -125,7 +125,7 @@
       "name": "ElectricCurrent",
       "symbol": "I",
       "dimensionalFormula": { "electricCurrent": 1 },
-      "availableUnits": ["Ampere"],
+      "availableUnits": ["Ampere", "Milliampere", "Kiloampere"],
       "quantities": {
         "vector0": { "base": "CurrentMagnitude" },
         "vector1": { "base": "Current1D" },
@@ -144,7 +144,7 @@
       "name": "Temperature",
       "symbol": "Θ",
       "dimensionalFormula": { "temperature": 1 },
-      "availableUnits": ["Kelvin", "Celsius", "Fahrenheit"],
+      "availableUnits": ["Kelvin", "Celsius", "Fahrenheit", "Rankine"],
       "quantities": {
         "vector0": { "base": "Temperature" },
         "vector1": {
@@ -164,7 +164,7 @@
       "name": "AmountOfSubstance",
       "symbol": "N",
       "dimensionalFormula": { "amountOfSubstance": 1 },
-      "availableUnits": ["Mole"],
+      "availableUnits": ["Mole", "Kilomole", "Millimole"],
       "quantities": {
         "vector0": { "base": "AmountOfSubstance" }
       },
@@ -177,7 +177,7 @@
       "name": "LuminousIntensity",
       "symbol": "J",
       "dimensionalFormula": { "luminousIntensity": 1 },
-      "availableUnits": ["Candela"],
+      "availableUnits": ["Candela", "Millicandela"],
       "quantities": {
         "vector0": { "base": "LuminousIntensity" }
       },
@@ -190,7 +190,7 @@
       "name": "Area",
       "symbol": "L²",
       "dimensionalFormula": { "length": 2 },
-      "availableUnits": ["SquareMeter", "SquareFoot", "SquareInch"],
+      "availableUnits": ["SquareMeter", "SquareKilometer", "SquareCentimeter", "SquareFoot", "SquareInch", "SquareMile", "Hectare", "Acre"],
       "quantities": {
         "vector0": {
           "base": "Area",
@@ -224,7 +224,7 @@
       "name": "Volume",
       "symbol": "L³",
       "dimensionalFormula": { "length": 3 },
-      "availableUnits": ["CubicMeter", "Liter", "Milliliter", "Gallon"],
+      "availableUnits": ["CubicMeter", "Liter", "Milliliter", "CubicCentimeter", "CubicFoot", "CubicInch", "Gallon", "ImperialGallon", "USQuart", "USPint", "USFluidOunce"],
       "quantities": {
         "vector0": {
           "base": "Volume",
@@ -245,7 +245,7 @@
       "symbol": "L T⁻¹",
       "dimensionalFormula": { "length": 1, "time": -1 },
       "availableUnits": [
-        "MetersPerSecond", "KilometersPerHour", "MilesPerHour"
+        "MetersPerSecond", "KilometersPerHour", "MilesPerHour", "FeetPerSecond", "Knot"
       ],
       "quantities": {
         "vector0": {
@@ -283,7 +283,7 @@
       "name": "Acceleration",
       "symbol": "L T⁻²",
       "dimensionalFormula": { "length": 1, "time": -2 },
-      "availableUnits": ["MetersPerSecondSquared"],
+      "availableUnits": ["MetersPerSecondSquared", "StandardGravity"],
       "quantities": {
         "vector0": {
           "base": "AccelerationMagnitude",
@@ -354,7 +354,7 @@
       "name": "Frequency",
       "symbol": "T⁻¹",
       "dimensionalFormula": { "time": -1 },
-      "availableUnits": ["Hertz"],
+      "availableUnits": ["Hertz", "Kilohertz", "Megahertz"],
       "quantities": {
         "vector0": {
           "base": "Frequency",
@@ -378,7 +378,7 @@
       "name": "RadioactiveActivity",
       "symbol": "T⁻¹",
       "dimensionalFormula": { "time": -1 },
-      "availableUnits": ["Becquerel"],
+      "availableUnits": ["Becquerel", "Curie"],
       "quantities": {
         "vector0": { "base": "RadioactiveActivity" }
       },
@@ -391,7 +391,7 @@
       "name": "AngularDisplacement",
       "symbol": "1",
       "dimensionalFormula": {},
-      "availableUnits": ["Radian", "Degree"],
+      "availableUnits": ["Radian", "Degree", "Gradian", "Revolution", "Milliradian"],
       "quantities": {
         "vector0": {
           "base": "Angle",
@@ -527,7 +527,7 @@
       "name": "Force",
       "symbol": "M L T⁻²",
       "dimensionalFormula": { "mass": 1, "length": 1, "time": -2 },
-      "availableUnits": ["Newton"],
+      "availableUnits": ["Newton", "Kilonewton", "Dyne", "PoundForce"],
       "quantities": {
         "vector0": {
           "base": "ForceMagnitude",
@@ -590,7 +590,7 @@
       "name": "Pressure",
       "symbol": "M L⁻¹ T⁻²",
       "dimensionalFormula": { "mass": 1, "length": -1, "time": -2 },
-      "availableUnits": ["Pascal", "Bar", "Atmosphere", "Psi"],
+      "availableUnits": ["Pascal", "Kilopascal", "Bar", "Atmosphere", "Psi", "Torr"],
       "quantities": {
         "vector0": {
           "base": "Pressure",
@@ -615,7 +615,7 @@
       "name": "Energy",
       "symbol": "M L² T⁻²",
       "dimensionalFormula": { "mass": 1, "length": 2, "time": -2 },
-      "availableUnits": ["Joule", "ElectronVolt", "Calorie", "KilowattHour"],
+      "availableUnits": ["Joule", "Kilojoule", "ElectronVolt", "Calorie", "Kilocalorie", "KilowattHour", "WattHour", "Erg", "Btu"],
       "quantities": {
         "vector0": {
           "base": "Energy",
@@ -640,7 +640,7 @@
       "name": "Power",
       "symbol": "M L² T⁻³",
       "dimensionalFormula": { "mass": 1, "length": 2, "time": -3 },
-      "availableUnits": ["Watt", "Horsepower"],
+      "availableUnits": ["Watt", "Kilowatt", "Megawatt", "Horsepower"],
       "quantities": {
         "vector0": {
           "base": "Power",
@@ -663,7 +663,7 @@
       "name": "AbsorbedDose",
       "symbol": "L² T⁻²",
       "dimensionalFormula": { "length": 2, "time": -2 },
-      "availableUnits": ["Gray"],
+      "availableUnits": ["Gray", "Rad"],
       "quantities": {
         "vector0": { "base": "AbsorbedDose" }
       },
@@ -676,7 +676,7 @@
       "name": "EquivalentDose",
       "symbol": "L² T⁻²",
       "dimensionalFormula": { "length": 2, "time": -2 },
-      "availableUnits": ["Sievert"],
+      "availableUnits": ["Sievert", "Rem"],
       "quantities": {
         "vector0": { "base": "EquivalentDose" }
       },
@@ -689,7 +689,7 @@
       "name": "Density",
       "symbol": "M L⁻³",
       "dimensionalFormula": { "mass": 1, "length": -3 },
-      "availableUnits": ["KilogramPerCubicMeter"],
+      "availableUnits": ["KilogramPerCubicMeter", "GramPerCubicCentimeter", "GramPerLiter"],
       "quantities": {
         "vector0": { "base": "Density" }
       },
@@ -704,7 +704,7 @@
       "name": "ElectricCharge",
       "symbol": "I T",
       "dimensionalFormula": { "electricCurrent": 1, "time": 1 },
-      "availableUnits": ["Coulomb"],
+      "availableUnits": ["Coulomb", "AmpereHour"],
       "quantities": {
         "vector0": { "base": "ChargeMagnitude" },
         "vector1": { "base": "Charge" }
@@ -722,7 +722,7 @@
       "dimensionalFormula": {
         "mass": 1, "length": 2, "time": -3, "electricCurrent": -1
       },
-      "availableUnits": ["Volt"],
+      "availableUnits": ["Volt", "Kilovolt"],
       "quantities": {
         "vector0": {
           "base": "VoltageMagnitude",
@@ -770,7 +770,7 @@
       "dimensionalFormula": {
         "mass": 1, "length": 2, "time": -3, "electricCurrent": -2
       },
-      "availableUnits": ["Ohm"],
+      "availableUnits": ["Ohm", "Kilohm", "Megohm"],
       "quantities": {
         "vector0": { "base": "Resistance" }
       },
@@ -787,7 +787,7 @@
       "dimensionalFormula": {
         "mass": -1, "length": -2, "time": 4, "electricCurrent": 2
       },
-      "availableUnits": ["Farad"],
+      "availableUnits": ["Farad", "Microfarad", "Nanofarad", "Picofarad"],
       "quantities": {
         "vector0": { "base": "Capacitance" }
       },
@@ -817,7 +817,7 @@
       "name": "Illuminance",
       "symbol": "J L⁻²",
       "dimensionalFormula": { "luminousIntensity": 1, "length": -2 },
-      "availableUnits": ["Lux"],
+      "availableUnits": ["Lux", "FootCandle"],
       "quantities": {
         "vector0": {
           "base": "Illuminance",
@@ -850,7 +850,7 @@
       "name": "Concentration",
       "symbol": "N L⁻³",
       "dimensionalFormula": { "amountOfSubstance": 1, "length": -3 },
-      "availableUnits": ["Molar"],
+      "availableUnits": ["Molar", "Millimolar", "Micromolar"],
       "quantities": {
         "vector0": { "base": "Concentration" }
       },
@@ -966,7 +966,7 @@
       "name": "DynamicViscosity",
       "symbol": "M L⁻¹ T⁻¹",
       "dimensionalFormula": { "mass": 1, "length": -1, "time": -1 },
-      "availableUnits": ["PascalSecond", "Poise"],
+      "availableUnits": ["PascalSecond", "Poise", "Centipoise"],
       "quantities": {
         "vector0": { "base": "DynamicViscosity" }
       },
@@ -1011,7 +1011,7 @@
       "name": "SurfaceTension",
       "symbol": "M T⁻²",
       "dimensionalFormula": { "mass": 1, "time": -2 },
-      "availableUnits": ["NewtonPerMeter"],
+      "availableUnits": ["NewtonPerMeter", "DynePerCentimeter"],
       "quantities": {
         "vector0": { "base": "SurfaceTension" }
       },
@@ -1026,7 +1026,7 @@
       "name": "MolarMass",
       "symbol": "M N⁻¹",
       "dimensionalFormula": { "mass": 1, "amountOfSubstance": -1 },
-      "availableUnits": ["KilogramPerMole", "GramPerMole"],
+      "availableUnits": ["KilogramPerMole", "GramPerMole", "Dalton"],
       "quantities": {
         "vector0": { "base": "MolarMass" }
       },
@@ -1041,7 +1041,7 @@
       "name": "CatalyticActivity",
       "symbol": "N T⁻¹",
       "dimensionalFormula": { "amountOfSubstance": 1, "time": -1 },
-      "availableUnits": ["Katal"],
+      "availableUnits": ["Katal", "EnzymeUnit"],
       "quantities": {
         "vector0": {
           "base": "CatalyticActivity",
@@ -1076,7 +1076,7 @@
       "name": "MolarEnergy",
       "symbol": "M L² T⁻² N⁻¹",
       "dimensionalFormula": { "mass": 1, "length": 2, "time": -2, "amountOfSubstance": -1 },
-      "availableUnits": ["JoulePerMole", "KilojoulePerMole"],
+      "availableUnits": ["JoulePerMole", "KilojoulePerMole", "CaloriePerMole"],
       "quantities": {
         "vector0": {
           "base": "MolarEnergy",
@@ -1198,7 +1198,7 @@
       "name": "Exposure",
       "symbol": "M⁻¹ T I",
       "dimensionalFormula": { "mass": -1, "time": 1, "electricCurrent": 1 },
-      "availableUnits": ["CoulombPerKilogram"],
+      "availableUnits": ["CoulombPerKilogram", "Roentgen"],
       "quantities": {
         "vector0": { "base": "Exposure" }
       },

--- a/Semantics.SourceGenerators/Metadata/domains.json
+++ b/Semantics.SourceGenerators/Metadata/domains.json
@@ -69,7 +69,19 @@
     },
     {
       "name": "FluidMechanics",
-      "description": "The study of fluids (liquids and gases) in motion and at rest, including fluid properties, flow dynamics, viscosity, pressure, and fluid-structure interactions"
+      "description": "The study of fluids (liquids and gases) in motion and at rest, including fluid properties, flow dynamics, viscosity, pressure, and fluid-structure interactions",
+      "constants": [
+        {
+          "name": "StandardAirDensity",
+          "description": "Standard air density at 15°C and 1 atm: 1.225 kg/m³ (ISO 2533)",
+          "value": "1.225"
+        },
+        {
+          "name": "WaterSurfaceTension",
+          "description": "Water surface tension at 20°C: 0.0728 N/m (NIST)",
+          "value": "0.0728"
+        }
+      ]
     },
     {
       "name": "StructuralMechanics",
@@ -77,7 +89,19 @@
     },
     {
       "name": "NuclearPhysics",
-      "description": "The study of atomic nuclei, radioactivity, nuclear reactions, decay processes, and radiation interactions with matter"
+      "description": "The study of atomic nuclei, radioactivity, nuclear reactions, decay processes, and radiation interactions with matter",
+      "constants": [
+        {
+          "name": "AtomicMassUnit",
+          "description": "Atomic mass unit: 1.66053906660 × 10⁻²⁷ kg (2018 CODATA)",
+          "value": "1.66053906660e-27"
+        },
+        {
+          "name": "NuclearMagneton",
+          "description": "Nuclear magneton: 5.0507837461 × 10⁻²⁷ J/T (2018 CODATA)",
+          "value": "5.0507837461e-27"
+        }
+      ]
     },
     {
       "name": "ParticlePhysics",
@@ -131,7 +155,14 @@
     },
     {
       "name": "Optics",
-      "description": "The physics of light and optical phenomena, including electromagnetic radiation, photometry, illumination, optical properties, and light-matter interactions"
+      "description": "The physics of light and optical phenomena, including electromagnetic radiation, photometry, illumination, optical properties, and light-matter interactions",
+      "constants": [
+        {
+          "name": "LuminousEfficacy",
+          "description": "Luminous efficacy of monochromatic radiation at 540 THz: 683 lm/W (exact, SI defining constant)",
+          "value": "683.0"
+        }
+      ]
     },
     {
       "name": "AngularMechanics",
@@ -156,7 +187,29 @@
     },
     {
       "name": "Acoustics",
-      "description": "The physics of sound and vibration, including wave propagation, acoustic properties, sound intensity, frequency analysis, and audio-related measurements"
+      "description": "The physics of sound and vibration, including wave propagation, acoustic properties, sound intensity, frequency analysis, and audio-related measurements",
+      "constants": [
+        {
+          "name": "ReferenceSoundPressure",
+          "description": "Reference sound pressure: 20 × 10⁻⁶ Pa (threshold of hearing)",
+          "value": "20e-6"
+        },
+        {
+          "name": "ReferenceSoundIntensity",
+          "description": "Reference sound intensity: 1 × 10⁻¹² W/m² (threshold of hearing)",
+          "value": "1e-12"
+        },
+        {
+          "name": "ReferenceSoundPower",
+          "description": "Reference sound power: 1 × 10⁻¹² W",
+          "value": "1e-12"
+        },
+        {
+          "name": "SabineConstant",
+          "description": "Sabine reverberation constant: 0.161 s/m",
+          "value": "0.161"
+        }
+      ]
     },
     {
       "name": "Chemistry",

--- a/Semantics.SourceGenerators/Metadata/units.json
+++ b/Semantics.SourceGenerators/Metadata/units.json
@@ -260,6 +260,198 @@
           "system": "Other",
           "conversionFactor": "DegreeToRadians",
           "factoryName": "Degrees"
+        },
+        {
+          "name": "NauticalMile",
+          "symbol": "nmi",
+          "description": "Nautical mile - 1852 meters, used in navigation.",
+          "system": "Other",
+          "conversionFactor": "NauticalMileToMeters",
+          "factoryName": "NauticalMiles"
+        },
+        {
+          "name": "Stone",
+          "symbol": "st",
+          "description": "Stone - Imperial unit of mass (14 pounds).",
+          "system": "Imperial",
+          "conversionFactor": "StoneToKilograms",
+          "factoryName": "Stone"
+        },
+        {
+          "name": "ShortTon",
+          "symbol": "ton",
+          "description": "Short ton - US customary unit of mass (2000 pounds).",
+          "system": "USCustomary",
+          "conversionFactor": "ShortTonToKilograms",
+          "factoryName": "ShortTons"
+        },
+        {
+          "name": "AtomicMassUnit",
+          "symbol": "u",
+          "description": "Atomic mass unit - 1/12 the mass of a carbon-12 atom.",
+          "system": "Atomic",
+          "conversionFactor": "AtomicMassUnitToKilograms",
+          "factoryName": "AtomicMassUnits"
+        },
+        {
+          "name": "Week",
+          "symbol": "wk",
+          "description": "Week - 7 days.",
+          "system": "Other",
+          "conversionFactor": "WeekToSeconds",
+          "factoryName": "Weeks"
+        },
+        {
+          "name": "Nanosecond",
+          "symbol": "ns",
+          "description": "Nanosecond - 1e-9 seconds.",
+          "system": "SIDerived",
+          "magnitude": "Nano",
+          "factoryName": "Nanoseconds"
+        },
+        {
+          "name": "SquareKilometer",
+          "symbol": "km²",
+          "description": "Square kilometer - 1e6 square meters.",
+          "system": "SIDerived",
+          "conversionFactor": "SquareKilometerToSquareMeters",
+          "factoryName": "SquareKilometers"
+        },
+        {
+          "name": "SquareCentimeter",
+          "symbol": "cm²",
+          "description": "Square centimeter - 1e-4 square meters.",
+          "system": "SIDerived",
+          "conversionFactor": "SquareCentimeterToSquareMeters",
+          "factoryName": "SquareCentimeters"
+        },
+        {
+          "name": "SquareMile",
+          "symbol": "mi²",
+          "description": "Square mile - Imperial unit of area.",
+          "system": "Imperial",
+          "conversionFactor": "SquareMileToSquareMeters",
+          "factoryName": "SquareMiles"
+        },
+        {
+          "name": "Hectare",
+          "symbol": "ha",
+          "description": "Hectare - metric unit of area (10000 m²).",
+          "system": "Metric",
+          "conversionFactor": "HectareToSquareMeters",
+          "factoryName": "Hectares"
+        },
+        {
+          "name": "Acre",
+          "symbol": "ac",
+          "description": "Acre - Imperial unit of area.",
+          "system": "Imperial",
+          "conversionFactor": "AcreToSquareMeters",
+          "factoryName": "Acres"
+        },
+        {
+          "name": "CubicCentimeter",
+          "symbol": "cm³",
+          "description": "Cubic centimeter - 1e-6 cubic meters.",
+          "system": "SIDerived",
+          "conversionFactor": "CubicCentimeterToCubicMeters",
+          "factoryName": "CubicCentimeters"
+        },
+        {
+          "name": "CubicFoot",
+          "symbol": "ft³",
+          "description": "Cubic foot - Imperial unit of volume.",
+          "system": "Imperial",
+          "conversionFactor": "CubicFootToCubicMeters",
+          "factoryName": "CubicFeet"
+        },
+        {
+          "name": "CubicInch",
+          "symbol": "in³",
+          "description": "Cubic inch - Imperial unit of volume.",
+          "system": "Imperial",
+          "conversionFactor": "CubicInchToCubicMeters",
+          "factoryName": "CubicInches"
+        },
+        {
+          "name": "ImperialGallon",
+          "symbol": "imp gal",
+          "description": "Imperial gallon - British unit of volume.",
+          "system": "Imperial",
+          "conversionFactor": "ImperialGallonToCubicMeters",
+          "factoryName": "ImperialGallons"
+        },
+        {
+          "name": "USQuart",
+          "symbol": "qt",
+          "description": "US liquid quart - US customary unit of volume.",
+          "system": "USCustomary",
+          "conversionFactor": "USQuartToCubicMeters",
+          "factoryName": "USQuarts"
+        },
+        {
+          "name": "USPint",
+          "symbol": "pt",
+          "description": "US liquid pint - US customary unit of volume.",
+          "system": "USCustomary",
+          "conversionFactor": "USPintToCubicMeters",
+          "factoryName": "USPints"
+        },
+        {
+          "name": "USFluidOunce",
+          "symbol": "fl oz",
+          "description": "US fluid ounce - US customary unit of volume.",
+          "system": "USCustomary",
+          "conversionFactor": "USFluidOunceToCubicMeters",
+          "factoryName": "USFluidOunces"
+        },
+        {
+          "name": "Gradian",
+          "symbol": "grad",
+          "description": "Gradian - 1/400 of a full circle (π/200 rad).",
+          "system": "Other",
+          "conversionFactor": "GradianToRadians",
+          "factoryName": "Gradians"
+        },
+        {
+          "name": "Revolution",
+          "symbol": "rev",
+          "description": "Revolution - one full circle (2π rad).",
+          "system": "Other",
+          "conversionFactor": "RevolutionToRadians",
+          "factoryName": "Revolutions"
+        },
+        {
+          "name": "Milliradian",
+          "symbol": "mrad",
+          "description": "Milliradian - 0.001 radians.",
+          "system": "SIDerived",
+          "magnitude": "Milli",
+          "factoryName": "Milliradians"
+        },
+        {
+          "name": "PartsPerMillion",
+          "symbol": "ppm",
+          "description": "Parts per million - 1e-6 dimensionless ratio.",
+          "system": "Other",
+          "conversionFactor": "PartsPerMillionToRatio",
+          "factoryName": "PartsPerMillion"
+        },
+        {
+          "name": "PartsPerBillion",
+          "symbol": "ppb",
+          "description": "Parts per billion - 1e-9 dimensionless ratio.",
+          "system": "Other",
+          "conversionFactor": "PartsPerBillionToRatio",
+          "factoryName": "PartsPerBillion"
+        },
+        {
+          "name": "PercentByWeight",
+          "symbol": "% w/w",
+          "description": "Percent by weight - mass fraction expressed as a percentage.",
+          "system": "Other",
+          "conversionFactor": "PercentByWeightToRatio",
+          "factoryName": "PercentByWeight"
         }
       ]
     },
@@ -430,6 +622,126 @@
           "description": "Meters per second to the fourth - SI derived unit of snap.",
           "system": "SIDerived",
           "factoryName": "MetersPerSecondQuartic"
+        },
+        {
+          "name": "FeetPerSecond",
+          "symbol": "ft/s",
+          "description": "Feet per second - Imperial unit of velocity.",
+          "system": "Imperial",
+          "conversionFactor": "FeetPerSecondToMetersPerSecond",
+          "factoryName": "FeetPerSecond"
+        },
+        {
+          "name": "Knot",
+          "symbol": "kn",
+          "description": "Knot - one nautical mile per hour.",
+          "system": "Other",
+          "conversionFactor": "KnotToMetersPerSecond",
+          "factoryName": "Knots"
+        },
+        {
+          "name": "StandardGravity",
+          "symbol": "g",
+          "description": "Standard gravity - acceleration of free fall at Earth's surface.",
+          "system": "Other",
+          "conversionFactor": "StandardGravityToMetersPerSecondSquared",
+          "factoryName": "StandardGravity"
+        },
+        {
+          "name": "Kilonewton",
+          "symbol": "kN",
+          "description": "Kilonewton - 1000 newtons.",
+          "system": "SIDerived",
+          "magnitude": "Kilo",
+          "factoryName": "Kilonewtons"
+        },
+        {
+          "name": "Dyne",
+          "symbol": "dyn",
+          "description": "Dyne - CGS unit of force.",
+          "system": "CGS",
+          "conversionFactor": "DyneToNewtons",
+          "factoryName": "Dynes"
+        },
+        {
+          "name": "PoundForce",
+          "symbol": "lbf",
+          "description": "Pound-force - Imperial unit of force.",
+          "system": "Imperial",
+          "conversionFactor": "PoundForceToNewtons",
+          "factoryName": "PoundsForce"
+        },
+        {
+          "name": "Kilopascal",
+          "symbol": "kPa",
+          "description": "Kilopascal - 1000 pascals.",
+          "system": "SIDerived",
+          "magnitude": "Kilo",
+          "factoryName": "Kilopascals"
+        },
+        {
+          "name": "Torr",
+          "symbol": "Torr",
+          "description": "Torr - 1/760 of a standard atmosphere.",
+          "system": "Other",
+          "conversionFactor": "TorrToPascals",
+          "factoryName": "Torr"
+        },
+        {
+          "name": "Kilojoule",
+          "symbol": "kJ",
+          "description": "Kilojoule - 1000 joules.",
+          "system": "SIDerived",
+          "magnitude": "Kilo",
+          "factoryName": "Kilojoules"
+        },
+        {
+          "name": "Kilocalorie",
+          "symbol": "kcal",
+          "description": "Kilocalorie - 1000 thermochemical calories.",
+          "system": "Other",
+          "conversionFactor": "KilocalorieToJoules",
+          "factoryName": "Kilocalories"
+        },
+        {
+          "name": "WattHour",
+          "symbol": "Wh",
+          "description": "Watt-hour - 3600 joules.",
+          "system": "SIDerived",
+          "conversionFactor": "WattHourToJoules",
+          "factoryName": "WattHours"
+        },
+        {
+          "name": "Erg",
+          "symbol": "erg",
+          "description": "Erg - CGS unit of energy.",
+          "system": "CGS",
+          "conversionFactor": "ErgToJoules",
+          "factoryName": "Ergs"
+        },
+        {
+          "name": "Btu",
+          "symbol": "BTU",
+          "description": "British thermal unit (IT) - Imperial unit of energy.",
+          "system": "Imperial",
+          "conversionFactor": "BtuToJoules",
+          "factoryName": "Btus"
+        },
+        {
+          "name": "Kilowatt",
+          "symbol": "kW",
+          "description": "Kilowatt - 1000 watts.",
+          "system": "SIDerived",
+          "magnitude": "Kilo",
+          "factoryName": "Kilowatts"
+        },
+        {
+          "name": "Megawatt",
+          "symbol": "MW",
+          "description": "Megawatt - 1e6 watts.",
+          "system": "SIDerived",
+          "magnitude": "Mega",
+          "factoryName": "Megawatts"
         }
       ]
     },
@@ -495,6 +807,14 @@
           "description": "Per kelvin - SI derived unit of thermal expansion coefficient.",
           "system": "SIDerived",
           "factoryName": "PerKelvin"
+        },
+        {
+          "name": "Rankine",
+          "symbol": "°R",
+          "description": "Rankine - absolute temperature scale with Fahrenheit-sized degrees.",
+          "system": "Imperial",
+          "conversionFactor": "FahrenheitScale",
+          "factoryName": "Rankine"
         }
       ]
     },
@@ -579,6 +899,78 @@
           "description": "Henry - SI derived unit of inductance.",
           "system": "SIDerived",
           "factoryName": "Henries"
+        },
+        {
+          "name": "Milliampere",
+          "symbol": "mA",
+          "description": "Milliampere - 0.001 amperes.",
+          "system": "SIDerived",
+          "magnitude": "Milli",
+          "factoryName": "Milliamperes"
+        },
+        {
+          "name": "Kiloampere",
+          "symbol": "kA",
+          "description": "Kiloampere - 1000 amperes.",
+          "system": "SIDerived",
+          "magnitude": "Kilo",
+          "factoryName": "Kiloamperes"
+        },
+        {
+          "name": "Kilovolt",
+          "symbol": "kV",
+          "description": "Kilovolt - 1000 volts.",
+          "system": "SIDerived",
+          "magnitude": "Kilo",
+          "factoryName": "Kilovolts"
+        },
+        {
+          "name": "Kilohm",
+          "symbol": "kΩ",
+          "description": "Kilohm - 1000 ohms.",
+          "system": "SIDerived",
+          "magnitude": "Kilo",
+          "factoryName": "Kilohms"
+        },
+        {
+          "name": "Megohm",
+          "symbol": "MΩ",
+          "description": "Megohm - 1e6 ohms.",
+          "system": "SIDerived",
+          "magnitude": "Mega",
+          "factoryName": "Megohms"
+        },
+        {
+          "name": "Microfarad",
+          "symbol": "μF",
+          "description": "Microfarad - 1e-6 farads.",
+          "system": "SIDerived",
+          "magnitude": "Micro",
+          "factoryName": "Microfarads"
+        },
+        {
+          "name": "Nanofarad",
+          "symbol": "nF",
+          "description": "Nanofarad - 1e-9 farads.",
+          "system": "SIDerived",
+          "magnitude": "Nano",
+          "factoryName": "Nanofarads"
+        },
+        {
+          "name": "Picofarad",
+          "symbol": "pF",
+          "description": "Picofarad - 1e-12 farads.",
+          "system": "SIDerived",
+          "magnitude": "Pico",
+          "factoryName": "Picofarads"
+        },
+        {
+          "name": "AmpereHour",
+          "symbol": "Ah",
+          "description": "Ampere-hour - 3600 coulombs of electric charge.",
+          "system": "SIDerived",
+          "conversionFactor": "AmpereHourToCoulombs",
+          "factoryName": "AmpereHours"
         }
       ]
     },
@@ -627,6 +1019,22 @@
           "description": "Hertz - SI derived unit of frequency.",
           "system": "SIDerived",
           "factoryName": "Hertz"
+        },
+        {
+          "name": "Kilohertz",
+          "symbol": "kHz",
+          "description": "Kilohertz - 1000 hertz.",
+          "system": "SIDerived",
+          "magnitude": "Kilo",
+          "factoryName": "Kilohertz"
+        },
+        {
+          "name": "Megahertz",
+          "symbol": "MHz",
+          "description": "Megahertz - 1e6 hertz.",
+          "system": "SIDerived",
+          "magnitude": "Mega",
+          "factoryName": "Megahertz"
         }
       ]
     },
@@ -661,6 +1069,22 @@
           "description": "Diopter - SI unit of optical power.",
           "system": "SIDerived",
           "factoryName": "Diopters"
+        },
+        {
+          "name": "Millicandela",
+          "symbol": "mcd",
+          "description": "Millicandela - 0.001 candelas.",
+          "system": "SIDerived",
+          "magnitude": "Milli",
+          "factoryName": "Millicandelas"
+        },
+        {
+          "name": "FootCandle",
+          "symbol": "fc",
+          "description": "Foot-candle - Imperial unit of illuminance (lumen per square foot).",
+          "system": "Imperial",
+          "conversionFactor": "FootCandleToLux",
+          "factoryName": "FootCandles"
         }
       ]
     },
@@ -703,6 +1127,38 @@
           "description": "Coulomb per kilogram - SI derived unit of radiation exposure.",
           "system": "SIDerived",
           "factoryName": "CoulombPerKilogram"
+        },
+        {
+          "name": "Curie",
+          "symbol": "Ci",
+          "description": "Curie - traditional unit of radioactive activity.",
+          "system": "Other",
+          "conversionFactor": "CurieToBecquerels",
+          "factoryName": "Curies"
+        },
+        {
+          "name": "Rad",
+          "symbol": "rad",
+          "description": "Rad - traditional unit of absorbed dose (0.01 Gy).",
+          "system": "Other",
+          "conversionFactor": "RadToGrays",
+          "factoryName": "Rads"
+        },
+        {
+          "name": "Rem",
+          "symbol": "rem",
+          "description": "Rem - traditional unit of equivalent dose (0.01 Sv).",
+          "system": "Other",
+          "conversionFactor": "RemToSieverts",
+          "factoryName": "Rems"
+        },
+        {
+          "name": "Roentgen",
+          "symbol": "R",
+          "description": "Roentgen - traditional unit of ionizing radiation exposure.",
+          "system": "Other",
+          "conversionFactor": "RoentgenToCoulombsPerKilogram",
+          "factoryName": "Roentgens"
         }
       ]
     },
@@ -716,6 +1172,22 @@
           "description": "Kilogram per cubic meter - SI derived unit of density.",
           "system": "SIDerived",
           "factoryName": "KilogramPerCubicMeter"
+        },
+        {
+          "name": "GramPerCubicCentimeter",
+          "symbol": "g/cm³",
+          "description": "Gram per cubic centimeter - 1000 kg/m³.",
+          "system": "SIDerived",
+          "conversionFactor": "GramPerCubicCentimeterToKilogramPerCubicMeter",
+          "factoryName": "GramPerCubicCentimeter"
+        },
+        {
+          "name": "GramPerLiter",
+          "symbol": "g/L",
+          "description": "Gram per liter - equal to one kilogram per cubic meter.",
+          "system": "SIDerived",
+          "conversionFactor": "GramPerLiterToKilogramPerCubicMeter",
+          "factoryName": "GramPerLiter"
         }
       ]
     },
@@ -737,6 +1209,38 @@
           "system": "SIDerived",
           "conversionFactor": "MolarToCubicMeter",
           "factoryName": "Molars"
+        },
+        {
+          "name": "Kilomole",
+          "symbol": "kmol",
+          "description": "Kilomole - 1000 moles.",
+          "system": "SIDerived",
+          "magnitude": "Kilo",
+          "factoryName": "Kilomoles"
+        },
+        {
+          "name": "Millimole",
+          "symbol": "mmol",
+          "description": "Millimole - 0.001 moles.",
+          "system": "SIDerived",
+          "magnitude": "Milli",
+          "factoryName": "Millimoles"
+        },
+        {
+          "name": "Millimolar",
+          "symbol": "mM",
+          "description": "Millimolar - 0.001 moles per liter (1 mol/m³).",
+          "system": "SIDerived",
+          "conversionFactor": "MillimolarToMolePerCubicMeter",
+          "factoryName": "Millimolars"
+        },
+        {
+          "name": "Micromolar",
+          "symbol": "μM",
+          "description": "Micromolar - 1e-6 moles per liter (0.001 mol/m³).",
+          "system": "SIDerived",
+          "conversionFactor": "MicromolarToMolePerCubicMeter",
+          "factoryName": "Micromolars"
         }
       ]
     },
@@ -802,6 +1306,22 @@
           "description": "Newton per meter - SI derived unit of surface tension.",
           "system": "SIDerived",
           "factoryName": "NewtonPerMeter"
+        },
+        {
+          "name": "Centipoise",
+          "symbol": "cP",
+          "description": "Centipoise - 0.001 pascal seconds (viscosity of water at 20°C ≈ 1 cP).",
+          "system": "CGS",
+          "conversionFactor": "CentipoiseToPascalSecond",
+          "factoryName": "Centipoise"
+        },
+        {
+          "name": "DynePerCentimeter",
+          "symbol": "dyn/cm",
+          "description": "Dyne per centimeter - CGS unit of surface tension.",
+          "system": "CGS",
+          "conversionFactor": "DynePerCentimeterToNewtonPerMeter",
+          "factoryName": "DynePerCentimeter"
         }
       ]
     },
@@ -852,6 +1372,30 @@
           "system": "SIDerived",
           "conversionFactor": "KilojoulePerMoleToJoulePerMole",
           "factoryName": "KilojoulePerMole"
+        },
+        {
+          "name": "CaloriePerMole",
+          "symbol": "cal/mol",
+          "description": "Calorie per mole - thermochemical calorie per mole.",
+          "system": "Other",
+          "conversionFactor": "CaloriePerMoleToJoulePerMole",
+          "factoryName": "CaloriesPerMole"
+        },
+        {
+          "name": "EnzymeUnit",
+          "symbol": "U",
+          "description": "Enzyme unit - one micromole of substrate per minute.",
+          "system": "Other",
+          "conversionFactor": "EnzymeUnitToKatals",
+          "factoryName": "EnzymeUnits"
+        },
+        {
+          "name": "Dalton",
+          "symbol": "Da",
+          "description": "Dalton - molar mass numerically equal to one gram per mole.",
+          "system": "Atomic",
+          "conversionFactor": "GramPerMoleToKilogramPerMole",
+          "factoryName": "Daltons"
         }
       ]
     },

--- a/Semantics.Test/Quantities/UnitBackfillTests.cs
+++ b/Semantics.Test/Quantities/UnitBackfillTests.cs
@@ -1,0 +1,231 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.Semantics.Test.Quantities;
+
+using ktsu.Semantics.Quantities;
+using ktsu.Semantics.Quantities.Units;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Covers the unit catalog backfilled from main (imperial/US/CGS/traditional units and
+/// SI-prefixed conveniences) plus the corrected Fahrenheit/Rankine affine conversions.
+/// </summary>
+[TestClass]
+public sealed class UnitBackfillTests
+{
+	private const double Tolerance = 1e-9;
+
+	// ---- Temperature: the affine conversion was inverted before the backfill ----
+
+	[TestMethod]
+	public void Temperature_FromFahrenheit_FreezingPoint_Is_273_15_Kelvin()
+	{
+		Temperature<double> t = Temperature<double>.FromFahrenheit(32.0);
+		Assert.AreEqual(273.15, t.Value, Tolerance);
+	}
+
+	[TestMethod]
+	public void Temperature_FromFahrenheit_BoilingPoint_Is_373_15_Kelvin()
+	{
+		Temperature<double> t = Temperature<double>.FromFahrenheit(212.0);
+		Assert.AreEqual(373.15, t.Value, Tolerance);
+	}
+
+	[TestMethod]
+	public void Temperature_In_Fahrenheit_RoundTrips()
+	{
+		Temperature<double> t = Temperature<double>.FromFahrenheit(98.6);
+		Assert.AreEqual(98.6, t.In(Units.Fahrenheit), Tolerance);
+	}
+
+	[TestMethod]
+	public void Temperature_FromRankine_Is_Absolute_With_Fahrenheit_Degrees()
+	{
+		Temperature<double> t = Temperature<double>.FromRankine(491.67);
+		Assert.AreEqual(273.15, t.Value, Tolerance);
+	}
+
+	// ---- Length / Area / Volume ----
+
+	[TestMethod]
+	public void Length_FromNauticalMiles_Is_1852_Meters()
+	{
+		Length<double> l = Length<double>.FromNauticalMiles(1.0);
+		Assert.AreEqual(1852.0, l.Value, Tolerance);
+		Assert.AreEqual(1.0, l.In(Units.NauticalMile), Tolerance);
+	}
+
+	[TestMethod]
+	public void Area_FromAcres_And_Hectares()
+	{
+		Assert.AreEqual(4046.8564224, Area<double>.FromAcres(1.0).Value, Tolerance);
+		Assert.AreEqual(10000.0, Area<double>.FromHectares(1.0).Value, Tolerance);
+		Assert.AreEqual(2589988.110336, Area<double>.FromSquareMiles(1.0).Value, Tolerance);
+		Assert.AreEqual(1e6, Area<double>.FromSquareKilometers(1.0).Value, Tolerance);
+	}
+
+	[TestMethod]
+	public void Volume_From_Imperial_And_US_Units()
+	{
+		Assert.AreEqual(0.028316846592, Volume<double>.FromCubicFeet(1.0).Value, Tolerance);
+		Assert.AreEqual(0.00454609, Volume<double>.FromImperialGallons(1.0).Value, Tolerance);
+		Assert.AreEqual(0.000946352946, Volume<double>.FromUSQuarts(1.0).Value, Tolerance);
+		Assert.AreEqual(1e-6, Volume<double>.FromCubicCentimeters(1.0).Value, Tolerance);
+	}
+
+	// ---- Mass ----
+
+	[TestMethod]
+	public void Mass_FromStone_And_ShortTons()
+	{
+		Assert.AreEqual(6.35029318, Mass<double>.FromStone(1.0).Value, Tolerance);
+		Assert.AreEqual(907.18474, Mass<double>.FromShortTons(1.0).Value, Tolerance);
+	}
+
+	[TestMethod]
+	public void Mass_FromAtomicMassUnits_Is_CODATA_Value()
+	{
+		Mass<double> m = Mass<double>.FromAtomicMassUnits(1.0);
+		Assert.AreEqual(1.66053906660e-27, m.Value, 1e-36);
+	}
+
+	// ---- Mechanics ----
+
+	[TestMethod]
+	public void Speed_FromKnots_Is_NauticalMilesPerHour()
+	{
+		Speed<double> s = Speed<double>.FromKnots(1.0);
+		Assert.AreEqual(1852.0 / 3600.0, s.Value, Tolerance);
+	}
+
+	[TestMethod]
+	public void AccelerationMagnitude_FromStandardGravity_Is_9_80665()
+	{
+		AccelerationMagnitude<double> a = AccelerationMagnitude<double>.FromStandardGravity(1.0);
+		Assert.AreEqual(9.80665, a.Value, Tolerance);
+	}
+
+	[TestMethod]
+	public void ForceMagnitude_FromPoundsForce_And_Dynes()
+	{
+		Assert.AreEqual(4.4482216152605, ForceMagnitude<double>.FromPoundsForce(1.0).Value, Tolerance);
+		Assert.AreEqual(1e-5, ForceMagnitude<double>.FromDynes(1.0).Value, Tolerance);
+	}
+
+	[TestMethod]
+	public void Pressure_FromKilopascals_And_Torr()
+	{
+		Assert.AreEqual(1000.0, Pressure<double>.FromKilopascals(1.0).Value, Tolerance);
+		Assert.AreEqual(101325.0, Pressure<double>.FromTorr(760.0).Value, 1e-6);
+	}
+
+	[TestMethod]
+	public void Energy_From_Btus_WattHours_Ergs_Kilocalories()
+	{
+		Assert.AreEqual(1055.05585262, Energy<double>.FromBtus(1.0).Value, Tolerance);
+		Assert.AreEqual(3600.0, Energy<double>.FromWattHours(1.0).Value, Tolerance);
+		Assert.AreEqual(1e-7, Energy<double>.FromErgs(1.0).Value, Tolerance);
+		Assert.AreEqual(4184.0, Energy<double>.FromKilocalories(1.0).Value, Tolerance);
+	}
+
+	[TestMethod]
+	public void Power_FromKilowatts_And_Megawatts()
+	{
+		Assert.AreEqual(1500.0, Power<double>.FromKilowatts(1.5).Value, Tolerance);
+		Assert.AreEqual(1e6, Power<double>.FromMegawatts(1.0).Value, Tolerance);
+	}
+
+	// ---- Electromagnetism ----
+
+	[TestMethod]
+	public void ChargeMagnitude_FromAmpereHours_Is_3600_Coulombs()
+	{
+		Assert.AreEqual(3600.0, ChargeMagnitude<double>.FromAmpereHours(1.0).Value, Tolerance);
+	}
+
+	[TestMethod]
+	public void Capacitance_From_SI_Prefixed_Farads()
+	{
+		Assert.AreEqual(1e-6, Capacitance<double>.FromMicrofarads(1.0).Value, 1e-15);
+		Assert.AreEqual(1e-12, Capacitance<double>.FromPicofarads(1.0).Value, 1e-21);
+	}
+
+	// ---- Frequency / angle / ratio ----
+
+	[TestMethod]
+	public void Frequency_FromKilohertz_And_Megahertz()
+	{
+		Assert.AreEqual(1000.0, Frequency<double>.FromKilohertz(1.0).Value, Tolerance);
+		Assert.AreEqual(1e6, Frequency<double>.FromMegahertz(1.0).Value, Tolerance);
+	}
+
+	[TestMethod]
+	public void Angle_FromGradians_And_Revolutions()
+	{
+		Assert.AreEqual(Math.PI, Angle<double>.FromGradians(200.0).Value, Tolerance);
+		Assert.AreEqual(2.0 * Math.PI, Angle<double>.FromRevolutions(1.0).Value, Tolerance);
+	}
+
+	[TestMethod]
+	public void Ratio_FromPartsPerMillion_And_Billion()
+	{
+		Assert.AreEqual(1e-6, Ratio<double>.FromPartsPerMillion(1.0).Value, 1e-15);
+		Assert.AreEqual(1e-9, Ratio<double>.FromPartsPerBillion(1.0).Value, 1e-18);
+	}
+
+	// ---- Chemistry ----
+
+	[TestMethod]
+	public void Concentration_FromMillimolars_Is_One_MolePerCubicMeter()
+	{
+		Assert.AreEqual(1.0, Concentration<double>.FromMillimolars(1.0).Value, Tolerance);
+	}
+
+	[TestMethod]
+	public void MolarMass_FromDaltons_Equals_GramPerMole()
+	{
+		Assert.AreEqual(0.001, MolarMass<double>.FromDaltons(1.0).Value, Tolerance);
+		Assert.AreEqual(MolarMass<double>.FromGramPerMole(1.0).Value, MolarMass<double>.FromDaltons(1.0).Value, Tolerance);
+	}
+
+	// ---- Radiology ----
+
+	[TestMethod]
+	public void Traditional_Radiological_Units_Convert_To_SI()
+	{
+		Assert.AreEqual(3.7e10, RadioactiveActivity<double>.FromCuries(1.0).Value, 1.0);
+		Assert.AreEqual(1.0, AbsorbedDose<double>.FromRads(100.0).Value, Tolerance);
+		Assert.AreEqual(1.0, EquivalentDose<double>.FromRems(100.0).Value, Tolerance);
+		Assert.AreEqual(2.58e-4, Exposure<double>.FromRoentgens(1.0).Value, 1e-12);
+	}
+
+	// ---- Density ----
+
+	[TestMethod]
+	public void Density_FromGramPerCubicCentimeter_Is_1000_KilogramPerCubicMeter()
+	{
+		Assert.AreEqual(1000.0, Density<double>.FromGramPerCubicCentimeter(1.0).Value, Tolerance);
+		Assert.AreEqual(1.0, Density<double>.FromGramPerLiter(1.0).Value, Tolerance);
+	}
+
+	// ---- Physical constants backfilled into domains.json ----
+
+	[TestMethod]
+	public void Acoustic_Reference_Constants_Are_Available()
+	{
+		Assert.AreEqual(20e-6, PhysicalConstants.Generic.ReferenceSoundPressure<double>(), 1e-12);
+		Assert.AreEqual(1e-12, PhysicalConstants.Generic.ReferenceSoundIntensity<double>(), 1e-21);
+		Assert.AreEqual(0.161, PhysicalConstants.Generic.SabineConstant<double>(), Tolerance);
+	}
+
+	[TestMethod]
+	public void Optical_Nuclear_And_Fluid_Constants_Are_Available()
+	{
+		Assert.AreEqual(683.0, PhysicalConstants.Generic.LuminousEfficacy<double>(), Tolerance);
+		Assert.AreEqual(5.0507837461e-27, PhysicalConstants.Generic.NuclearMagneton<double>(), 1e-36);
+		Assert.AreEqual(1.225, PhysicalConstants.Generic.StandardAirDensity<double>(), Tolerance);
+		Assert.AreEqual(0.0728, PhysicalConstants.Generic.WaterSurfaceTension<double>(), Tolerance);
+	}
+}


### PR DESCRIPTION
## Summary

First step of the parity plan: backfills the unit catalog and physical-constant domains that the vectors rework hadn't yet carried over from main, and fixes two real bugs found along the way.

### Units (~60 across 30 dimensions)
- **Imperial / US customary**: nautical mile, knot, feet-per-second, acre, hectare, square mile/km/cm, cubic foot/inch/cm, imperial gallon, US quart/pint/fluid-ounce, stone, short ton, pound-force, BTU, Rankine, foot-candle
- **CGS**: dyne, erg, centipoise, dyne-per-centimeter
- **Traditional radiological**: curie, rad, rem, roentgen
- **SI-prefixed conveniences**: kPa, kN, kJ, kW, MW, kHz, MHz, mA, kA, kV, kΩ, MΩ, μF/nF/pF, kmol/mmol, ns, mcd, mrad
- **Chemistry**: millimolar, micromolar, dalton, enzyme unit, calorie-per-mole, ampere-hour
- **Angle / ratio**: gradian, revolution, ppm, ppb, percent-by-weight, standard gravity, torr, watt-hour, kilocalorie, atomic mass unit, g/cm³, g/L

Each unit gets a named conversion factor in `conversions.json` (exact values where defined), an explicit plural `factoryName`, and `availableUnits` wiring — `From{Unit}` factories and typed `In(unit)` support come out of the generator.

### Constants
New domain constants in `domains.json`: **Acoustics** (reference sound pressure/intensity/power, Sabine constant), **Optics** (luminous efficacy), **NuclearPhysics** (atomic mass unit, nuclear magneton), **FluidMechanics** (standard air density, water surface tension).

### Bug fixes
1. **Fahrenheit conversion was inverted**: the metadata carried the K→F transform (×1.8, −459.67), so `Temperature.FromFahrenheit(32)` computed −402 K and threw on the V0 non-negativity guard. Now ×5/9 +255.372 (exact). Nothing had tested it.
2. **`PhysicalConstants.Generic.*<T>()` was entirely unusable**: `T.CreateChecked(PreciseNumber)` throws `NotSupportedException` (PreciseNumber's `TryConvertToChecked` is unimplemented). The generator now emits `PreciseNumber.To<T>()`, the supported materialisation path. Also previously untested.

### Deliberately not ported (with rationale)
- Luminance units (nit, cd/m², foot-lambert) — no Luminance dimension exists yet; belongs to the missing-quantities phase.
- `PerSecond` — no RateConstant dimension yet; same phase.
- `MolesPerSecond` — mislabelled on main (ReactionRate is volumetric, mol/(m³·s)).
- Main's `Mathematical` constant helpers (OneHalf, FourThirds…) — generated code uses literals.
- Dalton is defined as 1 g/mol on MolarMass rather than main's 1.66×10⁻²⁷ value, which was the per-particle mass, not a molar mass.

## Testing
- 26 new tests in `UnitBackfillTests` covering factories across all the new unit families, `In(unit)` round-trips, the Fahrenheit/Rankine fix, and the new constants.
- Full suite: 664 pass (638 before + 26 new), 0 quantity regressions; the 93 failures are the pre-existing Windows-path tests that don't apply on a Linux runner.
- Build clean, no SEM001–SEM004 diagnostics.

https://claude.ai/code/session_01AUgbNJjDBDCwcbUfPK3pGW

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUgbNJjDBDCwcbUfPK3pGW)_