### PR TITLE
Fix IDE0370 build errors from .NET 10 SDK analyzer

### DIFF
--- a/Semantics.Quantities/Core/SemanticQuantity.cs
+++ b/Semantics.Quantities/Core/SemanticQuantity.cs
@@ -67,7 +67,7 @@ public record SemanticQuantity<TSelf, TStorage>
 	{
 		Ensure.NotNull(self);
 		Ensure.NotNull(other);
-		return Create<TResult>(self.Quantity * other.Quantity)!;
+		return Create<TResult>(self.Quantity * other.Quantity);
 	}
 
 	/// <summary>
@@ -81,7 +81,7 @@ public record SemanticQuantity<TSelf, TStorage>
 		where TResult : SemanticQuantity<TStorage>, new()
 	{
 		Ensure.NotNull(self);
-		return Create<TResult>(self.Quantity * other)!;
+		return Create<TResult>(self.Quantity * other);
 	}
 
 	/// <summary>
@@ -96,7 +96,7 @@ public record SemanticQuantity<TSelf, TStorage>
 	{
 		Ensure.NotNull(self);
 		Ensure.NotNull(other);
-		return Create<TResult>(self.Quantity / other.Quantity)!;
+		return Create<TResult>(self.Quantity / other.Quantity);
 	}
 
 	/// <summary>
@@ -110,7 +110,7 @@ public record SemanticQuantity<TSelf, TStorage>
 		where TResult : SemanticQuantity<TStorage>, new()
 	{
 		Ensure.NotNull(self);
-		return Create<TResult>(self.Quantity / other)!;
+		return Create<TResult>(self.Quantity / other);
 	}
 
 	/// <summary>
@@ -142,7 +142,7 @@ public record SemanticQuantity<TSelf, TStorage>
 	{
 		Ensure.NotNull(self);
 		Ensure.NotNull(other);
-		return Create<TResult>(self.Quantity + other.Quantity)!;
+		return Create<TResult>(self.Quantity + other.Quantity);
 	}
 
 	/// <summary>
@@ -157,7 +157,7 @@ public record SemanticQuantity<TSelf, TStorage>
 	{
 		Ensure.NotNull(self);
 		Ensure.NotNull(other);
-		return Create<TResult>(self.Quantity - other.Quantity)!;
+		return Create<TResult>(self.Quantity - other.Quantity);
 	}
 
 	/// <summary>
@@ -170,7 +170,7 @@ public record SemanticQuantity<TSelf, TStorage>
 		where TResult : SemanticQuantity<TStorage>, new()
 	{
 		Ensure.NotNull(self);
-		return Create<TResult>(-self.Quantity)!;
+		return Create<TResult>(-self.Quantity);
 	}
 
 	/// <inheritdoc/>

--- a/Semantics.Strings/SemanticString.cs
+++ b/Semantics.Strings/SemanticString.cs
@@ -9,6 +9,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Reflection;
 using System.Text;
 using System.Text.Json.Serialization;
 
@@ -557,8 +558,9 @@ public abstract record SemanticString<TDerived> : ISemanticString
 		Ensure.NotNull(value);
 
 		Type typeOfTDest = typeof(TDest);
-		TDest newInstance = (TDest)Activator.CreateInstance(type: typeOfTDest)!;
-		typeOfTDest.GetProperty(name: nameof(WeakString))!.SetValue(obj: newInstance, value: newInstance.MakeCanonical(value));
+		TDest newInstance = (TDest)Ensure.NotNull(Activator.CreateInstance(type: typeOfTDest));
+		PropertyInfo weakStringProperty = Ensure.NotNull(typeOfTDest.GetProperty(name: nameof(WeakString)));
+		weakStringProperty.SetValue(obj: newInstance, value: newInstance.MakeCanonical(value));
 		return newInstance;
 	}
 


### PR DESCRIPTION
## Summary

Fixes the CI failure in [run 27384038671](https://github.com/ktsu-dev/Semantics/actions/runs/27384038671/job/80927076526), where the build failed with 32 `IDE0370: Suppression is unnecessary` errors raised by the .NET SDK 10.0.301 analyzers (with code-analysis warnings treated as errors).

> Note: the job shows a green check because the workflow's release step concluded successfully, but the KtsuBuild step logged `Build FAILED ... 32 Error(s)` / `CI/CD pipeline failed: Build failed with exit code 1`.

All 9 flagged locations were null-forgiving (`!`) operators:

- **`Semantics.Quantities/Core/SemanticQuantity.cs`** (7 locations): `Create<TResult>(...)` returns a non-nullable `TQuantity`, so the trailing `!` on the `Multiply`/`Divide`/`Add`/`Subtract`/`Negate` return statements was never needed. Removed.
- **`Semantics.Strings/SemanticString.cs`** (2 locations in `FromStringInternal`): IDE0370 fired in the `netstandard2.0`/`2.1` builds where the BCL reference assemblies are nullability-oblivious, but simply deleting the `!` would break the annotated `net5.0+` builds (`Activator.CreateInstance` returns `object?`, `Type.GetProperty` returns `PropertyInfo?`). Replaced the suppressions with `Ensure.NotNull(...)` (Polyfill), which is correct in both nullable contexts and fails fast with `ArgumentNullException` instead of a later NRE.

## Verification

Built `Semantics.Strings` (all 8 TFMs) and `Semantics.Quantities` (all 5 TFMs) in Release with the .NET 10 SDK: no `IDE0370` and no new nullable (`CS86xx`) diagnostics. (Local-only `IDE0055` formatting noise from LF line endings on Linux checkouts is pre-existing and does not occur on the Windows CI runners.)

https://claude.ai/code/session_01LBGrmJHgP4RpMC9dQ2Pdox

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBGrmJHgP4RpMC9dQ2Pdox)_