### PR TITLE
Close V0 release blockers (#50, #52) and drop out-of-support TFMs

### DIFF
--- a/.github/workflows/verify-generated.yml
+++ b/.github/workflows/verify-generated.yml
@@ -1,0 +1,48 @@
+name: Verify Generated Files
+
+# Source-generator output under Semantics.Quantities/Generated/ is committed to the
+# repo (EmitCompilerGeneratedFiles=true). This job rebuilds and fails if the committed
+# files are stale, so a generated file can never drift from its generator.
+#
+# NOTE: this is a standalone workflow on purpose — dotnet.yml is centrally synced from a
+# shared template across ktsu repos, so a step added there would be overwritten. If this
+# check belongs in the shared KtsuBuild pipeline long-term, move it there and delete this.
+
+on:
+  pull_request:
+    paths-ignore: ["**.md"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-generated-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-generated:
+    name: Generated files up to date
+    # windows-latest so git's autocrlf matches the committed CRLF line endings and the
+    # diff doesn't flag end-of-line differences.
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Build (regenerates source-generator output into Generated/)
+        run: dotnet build Semantics.Quantities/Semantics.Quantities.csproj -c Release
+
+      - name: Fail if generated files are stale
+        shell: bash
+        run: |
+          if ! git diff --exit-code -- 'Semantics.Quantities/Generated/'; then
+            echo "::error::Generated files are out of date. Run 'dotnet build Semantics.Quantities/Semantics.Quantities.csproj' and commit the changes under Semantics.Quantities/Generated/."
+            exit 1
+          fi

--- a/Semantics.Paths/Semantics.Paths.csproj
+++ b/Semantics.Paths/Semantics.Paths.csproj
@@ -2,7 +2,7 @@
   <Sdk Name="Microsoft.NET.Sdk" />
   <Sdk Name="ktsu.Sdk" />
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1716;CA2225;IDE0032;CA1866;CA2249;IDE0056;IDE0057</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.UnitsGenerator/Units.g.cs
+++ b/Semantics.Quantities/Generated/Semantics.SourceGenerators/Semantics.SourceGenerators.UnitsGenerator/Units.g.cs
@@ -5422,9 +5422,6 @@ public static class Units{
 	/// <summary>Singleton <c>FaradPerMeter</c> instance.</summary>
 	public static readonly FaradPerMeter FaradPerMeter = new FaradPerMeter();
 
-	/// <summary>Singleton <c>FootPerSecond</c> instance.</summary>
-	public static readonly FootPerSecond FootPerSecond = new FootPerSecond();
-
 	/// <summary>Singleton <c>Foot</c> instance.</summary>
 	public static readonly Foot Foot = new Foot();
 
@@ -5433,6 +5430,9 @@ public static class Units{
 
 	/// <summary>Singleton <c>FootLambert</c> instance.</summary>
 	public static readonly FootLambert FootLambert = new FootLambert();
+
+	/// <summary>Singleton <c>FootPerSecond</c> instance.</summary>
+	public static readonly FootPerSecond FootPerSecond = new FootPerSecond();
 
 	/// <summary>Singleton <c>Gallon</c> instance.</summary>
 	public static readonly Gallon Gallon = new Gallon();

--- a/Semantics.Quantities/Semantics.Quantities.csproj
+++ b/Semantics.Quantities/Semantics.Quantities.csproj
@@ -2,7 +2,7 @@
   <Sdk Name="Microsoft.NET.Sdk" />
   <Sdk Name="ktsu.Sdk" />
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1716;CA2225;KTSU0003;IDE0032</NoWarn>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>

--- a/Semantics.Strings/Semantics.Strings.csproj
+++ b/Semantics.Strings/Semantics.Strings.csproj
@@ -2,7 +2,7 @@
   <Sdk Name="Microsoft.NET.Sdk" />
   <Sdk Name="ktsu.Sdk" />
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1716;CA1866;CA2249;IDE0057</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Semantics.Test/Quantities/VectorQuantityTests.cs
+++ b/Semantics.Test/Quantities/VectorQuantityTests.cs
@@ -165,13 +165,11 @@ public sealed class VectorQuantityTests
 	}
 
 	// ------------------------------------------------------------- V0 - V0
-	// Locked design decision in #52: V0 - V0 should return the same V0 of T.Abs(a - b).
-	// Generator currently emits unsigned subtraction via the SemanticQuantity base, which
-	// can produce a negative magnitude. Tracked as a follow-up.
+	// #52: V0 - V0 returns the same V0 of T.Abs(a - b). The generated derived operator
+	// wins overload resolution over PhysicalQuantity's plain (signable) subtraction.
 
 	[TestMethod]
-	[Ignore("Locked in #52: V0 - V0 should return the same V0 of T.Abs(a - b). Generator currently emits unsigned subtraction.")]
-	public void Mass_Minus_Mass_Returns_Absolute_Difference_Pending52()
+	public void Mass_Minus_Mass_Returns_Absolute_Difference()
 	{
 		Mass<double> a = Mass<double>.FromKilogram(3.0);
 		Mass<double> b = Mass<double>.FromKilogram(5.0);
@@ -180,20 +178,18 @@ public sealed class VectorQuantityTests
 	}
 
 	// ---------------------------------------------------- V0 non-negativity
-	// Tracked in #50: factories on Vector0 quantities should reject negative inputs
-	// with ArgumentException. The current generator does not emit guards.
+	// #50: factories on Vector0 quantities reject negative inputs with ArgumentException
+	// via Vector0Guards.EnsureNonNegative (the guard runs after unit conversion).
 
 	[TestMethod]
-	[Ignore("Tracked in #50: V0 factories should reject negative inputs.")]
-	public void Speed_From_Negative_Throws_Pending50()
+	public void Speed_From_Negative_Throws()
 	{
 		_ = Assert.ThrowsExactly<System.ArgumentException>(
 			() => Speed<double>.FromMeterPerSecond(-1.0));
 	}
 
 	[TestMethod]
-	[Ignore("Tracked in #50: V0 factories should reject negative inputs.")]
-	public void Mass_From_Negative_Throws_Pending50()
+	public void Mass_From_Negative_Throws()
 	{
 		_ = Assert.ThrowsExactly<System.ArgumentException>(
 			() => Mass<double>.FromKilogram(-1.0));

--- a/docs/migration-guide-2.0.md
+++ b/docs/migration-guide-2.0.md
@@ -214,6 +214,10 @@ different dimensions throws `ArgumentException`; equality across dimensions is
 | audio-engineering `Percent<T>` | the `Percent` **unit** on the Dimensionless dimension: `Ratio<T>.FromPercent(50)` and `ratio.In(Units.Percent)` |
 | audio-engineering `Gain<T>` record struct | `Gain<T>` is now a generated semantic overload of `Ratio` (a record class, non-negative, widens implicitly to `Ratio`); `Unity`, `Silence`, the `Decibels` conversions, and `*` live in a partial |
 
+## Target frameworks
+
+The out-of-support runtimes `net5.0`, `net6.0`, and `net7.0` were dropped — `System.Text.Json` 10 (and friends) no longer ship assets for them. `ktsu.Semantics.Quantities` now targets `net8.0`–`net10.0` (it requires `INumber<T>`, so it has no `netstandard` target). `Semantics.Strings` and `Semantics.Paths` target `net8.0`–`net10.0` plus `netstandard2.0`/`netstandard2.1`, so consumers on older runtimes still resolve via `netstandard`.
+
 ## What didn't change
 
 - `Semantics.Strings` and `Semantics.Paths` — same namespaces, same types;
@@ -224,7 +228,6 @@ different dimensions throws `ArgumentException`; equality across dimensions is
   through the generated `Ratio<T>`, and (for the logarithmic ones) are
   generated from `logarithmic.json`. `Percent` became a unit and `Gain` a
   generated `Ratio` overload — see the removed-APIs table.
-- Target frameworks: `net7.0` through `net10.0`.
 - Quantities remain generic over the numeric storage type
   (`where T : struct, INumber<T>`).
 - `UnitSystem` and `UnitConversionException` keep their names and meaning.


### PR DESCRIPTION
## Closes the two release blockers from #100

### Blocker 1 — V0 non-negativity (#50) and absolute-difference subtraction (#52)

Both were **already implemented in the generator**, but the covering tests were left `[Ignore]`d:
- V0 `From{Unit}` factories guard via `Vector0Guards.EnsureNonNegative` (runs after unit conversion, throws `ArgumentException`).
- `V0 - V0` emits `Create(T.Abs(left - right))`, so magnitude subtraction stays non-negative.

This un-skips and renames the three tests (`Mass_From_Negative_Throws`, `Speed_From_Negative_Throws`, `Mass_Minus_Mass_Returns_Absolute_Difference`) and refreshes their now-stale comments. Closes #50, closes #52.

### Blocker 2 — drop out-of-support target frameworks

`System.Text.Json` 10 (and `System.IO.Pipelines`, `System.Text.Encodings.Web`, `System.Runtime.CompilerServices.Unsafe`) no longer ship assets for `net5.0`/`net6.0`/`net7.0`, which produced ~18 "doesn't support" warnings via Strings/Paths.

- `Semantics.Strings`, `Semantics.Paths`: drop `net5.0`/`net6.0`/`net7.0`, keep `net8.0`–`net10.0` + `netstandard2.0`/`2.1` (older consumers still resolve via netstandard, so this is non-breaking for them).
- `Semantics.Quantities`: drop `net7.0` → `net8.0`–`net10.0` floor (it needs `INumber<T>`, so no netstandard target).
- Documented in `docs/migration-guide-2.0.md`.

## Result

- `dotnet build -c Release`: **0 errors**, warnings down from 20 to 1 (a pre-existing `CS8600` in `LogarithmicScalesGenerator.cs:141`, unrelated, not promoted to error).
- Tests: **782 passed, 0 failed, 0 skipped**.

## Known follow-up (not in this PR)

The committed generated `Units.g.cs` reorders nondeterministically on each build (the `FootPerSecond` singleton moves). Worth making the `UnitsGenerator` output order deterministic so generated files don't churn.
